### PR TITLE
Emscripten - audio improvements

### DIFF
--- a/include/devdsp.h
+++ b/include/devdsp.h
@@ -21,4 +21,5 @@
 
 FsOpenNode* openDevDsp(const std::shared_ptr<FsNode>& node, U32 flags, U32 data);
 void dspShutdown();
+void dspSetMaxOutputFreq(U32 freq);
 #endif

--- a/include/kdspaudio.h
+++ b/include/kdspaudio.h
@@ -36,6 +36,7 @@ public:
 	virtual void closeAudio() = 0;
 	virtual U32 writeAudio(U8* data, U32 len) = 0;
 	virtual U32 getFragmentSize() = 0;
+	virtual void setFragmentSize(U32 size) = 0;
 	virtual U32 getBufferSize() = 0;
 	virtual U32 getBufferCapacity() = 0;
 

--- a/platform/sdl/kdspaudio.cpp
+++ b/platform/sdl/kdspaudio.cpp
@@ -60,6 +60,7 @@ public:
 	void closeAudio() override;
 	U32 writeAudio(U8* data, U32 len) override;
 	U32 getFragmentSize() override {return this->dspFragSize;}
+	void setFragmentSize(U32 size) override;
 	U32 getBufferSize() override {return this->getGuestQueuedAudioSizeWant();}
 	U32 getBufferCapacity() override { return DSP_BUFFER_SIZE;}
 
@@ -394,6 +395,19 @@ void KDspAudioSdl::closeAudio() {
 		SDL_CloseAudioDevice(this->deviceId);
 		this->deviceId = 0;
 	}
+}
+
+void KDspAudioSdl::setFragmentSize(U32 size) {
+#ifdef __EMSCRIPTEN__
+	size = std::clamp(size, (U32)256, (U32)4096);
+#else
+	size = std::clamp(size, (U32)512, (U32)16384);
+#endif
+	U32 blockSize = bytesPerSampleWant() * want.channels;
+	if (blockSize) {
+		size &= ~(blockSize - 1);
+	}
+	this->dspFragSize = size ? size : blockSize;
 }
 
 U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {	

--- a/platform/sdl/kdspaudio.cpp
+++ b/platform/sdl/kdspaudio.cpp
@@ -48,6 +48,9 @@ public:
 		if (this->cvtBuf) {
 			SDL_free(this->cvtBuf);
 		}
+		if (this->stream) {
+			SDL_FreeAudioStream(this->stream);
+		}
 		if (this->deviceId) {
 			SDL_CloseAudioDevice(this->deviceId);
 			this->deviceId = 0;
@@ -131,9 +134,11 @@ public:
 	SDL_AudioSpec want = { 0 };
 	SDL_AudioSpec got = { 0 };
 	SDL_AudioCVT cvt = { 0 };
+	SDL_AudioStream* stream = nullptr;
 	U32 openedFormat = 0;
 	int cvtBufLen = 0;
 	unsigned char* cvtBuf = nullptr;
+	std::vector<U8> streamBuffer;
 	bool sameFormat = false;
 	U32 dspFragSize = 4096;
 	bool open = false;
@@ -267,6 +272,10 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
 			SDL_CloseAudioDevice(this->deviceId);
 			this->deviceId = 0;
 		}
+		if (this->stream) {
+			SDL_FreeAudioStream(this->stream);
+			this->stream = nullptr;
+		}
 	}
 
     SDL_AudioSpec requested = this->want;
@@ -284,7 +293,10 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
 
 	if (this->want.freq != this->got.freq || this->want.channels != this->got.channels || this->want.format != this->got.format) {
 		this->sameFormat = false;
-		SDL_BuildAudioCVT(&this->cvt, this->want.format, this->want.channels, this->want.freq, this->got.format, this->got.channels, this->got.freq);
+		this->stream = SDL_NewAudioStream(this->want.format, this->want.channels, this->want.freq, this->got.format, this->got.channels, this->got.freq);
+		if (!this->stream) {
+			SDL_BuildAudioCVT(&this->cvt, this->want.format, this->want.channels, this->want.freq, this->got.format, this->got.channels, this->got.freq);
+		}
 	} else {
 		this->sameFormat = true;
 	}
@@ -367,7 +379,21 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 		return -K_EWOULDBLOCK;
 	}
 
-	if (!this->sameFormat) {
+	if (!this->sameFormat && this->stream) {
+		if (SDL_AudioStreamPut(this->stream, data, (int)len) < 0) {
+			return 0;
+		}
+		int available = SDL_AudioStreamAvailable(this->stream);
+		if (available > 0) {
+			if ((int)this->streamBuffer.size() < available) {
+				this->streamBuffer.resize(available);
+			}
+			int got = SDL_AudioStreamGet(this->stream, this->streamBuffer.data(), available);
+			if (got > 0) {
+				SDL_QueueAudio(this->deviceId, this->streamBuffer.data(), got);
+			}
+		}
+	} else if (!this->sameFormat) {
 		int needed = (int)len * this->cvt.len_mult;
 		if (this->cvtBufLen && this->cvtBufLen < needed) {
 			SDL_free(this->cvtBuf);

--- a/platform/sdl/kdspaudio.cpp
+++ b/platform/sdl/kdspaudio.cpp
@@ -60,7 +60,7 @@ public:
 	void closeAudio() override;
 	U32 writeAudio(U8* data, U32 len) override;
 	U32 getFragmentSize() override {return this->dspFragSize;}
-	U32 getBufferSize() override {return (U32)0;}
+	U32 getBufferSize() override {return this->getGuestQueuedAudioSizeWant();}
 	U32 getBufferCapacity() override { return DSP_BUFFER_SIZE;}
 
 	U32 bytesPerSampleWant() {
@@ -69,6 +69,36 @@ public:
 
 	U32 bytesPerSampleGot() {
 		return SDL_AUDIO_BITSIZE(this->got.format) / 8;
+	}
+
+	U32 bytesPerSecondWant() {
+		return this->want.freq * this->want.channels * bytesPerSampleWant();
+	}
+
+	U32 bytesPerSecondGot() {
+		return this->got.freq * this->got.channels * bytesPerSampleGot();
+	}
+
+	U32 getQueuedAudioSizeWant() {
+		if (!KSystem::soundEnabled) {
+			return (U32)this->audioBuffer.size();
+		}
+		if (!this->deviceId) {
+			return 0;
+		}
+		U32 gotBytesPerSecond = bytesPerSecondGot();
+		if (!gotBytesPerSecond) {
+			return 0;
+		}
+		return (U32)(((U64)SDL_GetQueuedAudioSize(this->deviceId) * bytesPerSecondWant()) / gotBytesPerSecond);
+	}
+
+	U32 getGuestQueuedAudioSizeWant() {
+#ifdef __EMSCRIPTEN__
+		return this->getEstimatedRealQueuedWant();
+#else
+		return this->getQueuedAudioSizeWant();
+#endif
 	}
 
 	U32 getSdlFormat(U32 format) {
@@ -108,6 +138,138 @@ public:
 	bool open = false;
 	std::deque<U8> audioBuffer; // only used when KSystem::soundEnabled is false
 	SDL_AudioDeviceID deviceId = 0;
+#ifdef BOXEDWINE_AUDIO_DEBUG
+	U32 lastStatsTime = 0;
+	U32 lastWriteTime = 0;
+	U32 statsWrites = 0;
+	U32 statsBlocks = 0;
+	U32 statsPartialWrites = 0;
+	U32 statsLowQueue = 0;
+	U32 statsMaxWriteGap = 0;
+	U32 statsMinQueueWant = 0xFFFFFFFF;
+	U32 statsMaxQueueWant = 0;
+	U32 statsInBytes = 0;
+	U32 statsOutBytes = 0;
+	U32 statsSilenceBytes = 0;
+	U32 statsConvertMs = 0;
+#endif
+	U32 realQueuedWant = 0;
+	U32 lastRealQueuedTime = 0;
+	std::vector<U8> silenceBuffer;
+
+	U32 getEstimatedRealQueuedWant() {
+		U32 now = KSystem::getMilliesSinceStart();
+		if (!this->lastRealQueuedTime) {
+			this->lastRealQueuedTime = now;
+			return this->realQueuedWant;
+		}
+		U32 elapsed = now - this->lastRealQueuedTime;
+		if (elapsed) {
+			U32 consumed = (U32)(((U64)bytesPerSecondWant() * elapsed) / 1000);
+			this->realQueuedWant = consumed >= this->realQueuedWant ? 0 : this->realQueuedWant - consumed;
+			this->lastRealQueuedTime = now;
+		}
+		return this->realQueuedWant;
+	}
+
+	void addRealQueuedWant(U32 bytes) {
+		U32 queued = getEstimatedRealQueuedWant();
+		this->realQueuedWant = std::min((U32)DSP_BUFFER_SIZE, queued + bytes);
+	}
+
+	U32 topUpSilence() {
+#ifdef __EMSCRIPTEN__
+		if (!this->deviceId) {
+			return 0;
+		}
+		U32 gotBytesPerSecond = bytesPerSecondGot();
+		U32 frameSize = bytesPerSampleGot() * this->got.channels;
+		if (!gotBytesPerSecond || !frameSize) {
+			return 0;
+		}
+		U32 queued = SDL_GetQueuedAudioSize(this->deviceId);
+		U32 target = (gotBytesPerSecond * 96 / 1000) & ~(frameSize - 1);
+		if (queued >= target) {
+			return 0;
+		}
+		U32 bytes = (target - queued) & ~(frameSize - 1);
+		if (!bytes) {
+			return 0;
+		}
+		if (this->silenceBuffer.size() < bytes) {
+			this->silenceBuffer.resize(bytes);
+		}
+		SDL_memset(this->silenceBuffer.data(), this->got.silence, bytes);
+		SDL_QueueAudio(this->deviceId, this->silenceBuffer.data(), bytes);
+		return bytes;
+#else
+		return 0;
+#endif
+	}
+
+#ifdef BOXEDWINE_AUDIO_DEBUG
+	void recordAudioStats(U32 queuedBefore, U32 queuedAfter, U32 requestedLen, U32 acceptedLen, U32 queuedLen, U32 convertMs) {
+		U32 now = KSystem::getMilliesSinceStart();
+		if (!this->lastStatsTime) {
+			this->lastStatsTime = now;
+		}
+		if (this->lastWriteTime) {
+			this->statsMaxWriteGap = std::max(this->statsMaxWriteGap, now - this->lastWriteTime);
+		}
+		this->lastWriteTime = now;
+		this->statsWrites++;
+		this->statsInBytes += acceptedLen;
+		this->statsOutBytes += queuedLen;
+		this->statsConvertMs += convertMs;
+		if (acceptedLen < requestedLen) {
+			this->statsPartialWrites++;
+		}
+		this->statsMinQueueWant = std::min(this->statsMinQueueWant, queuedBefore);
+		this->statsMaxQueueWant = std::max(this->statsMaxQueueWant, queuedAfter);
+		if (queuedBefore < this->dspFragSize) {
+			this->statsLowQueue++;
+		}
+		if (now - this->lastStatsTime >= 1000) {
+			U32 statsMs = now - this->lastStatsTime;
+			U32 wantBytesPerSecond = bytesPerSecondWant();
+			U32 gotBytesPerSecond = bytesPerSecondGot();
+			U32 minQueueMs = wantBytesPerSecond ? (U32)(((U64)this->statsMinQueueWant * 1000) / wantBytesPerSecond) : 0;
+			U32 maxQueueMs = wantBytesPerSecond ? (U32)(((U64)this->statsMaxQueueWant * 1000) / wantBytesPerSecond) : 0;
+			U32 sdlQueueBytes = this->deviceId ? SDL_GetQueuedAudioSize(this->deviceId) : 0;
+			U32 sdlQueueMs = gotBytesPerSecond ? (U32)(((U64)sdlQueueBytes * 1000) / gotBytesPerSecond) : 0;
+			U32 expectedIn = (U32)(((U64)wantBytesPerSecond * statsMs) / 1000);
+			klog_fmt("audioStats: id=%d want=%d/%d/%x got=%d/%d/%x samples=%d same=%d ms=%d writes=%d in=%d expectIn=%d out=%d silence=%d block=%d partial=%d low=%d qWantMs=%d..%d qSdl=%dms/%dB gapMax=%dms cvtMs=%d",
+				this->id, this->want.freq, this->want.channels, this->want.format, this->got.freq, this->got.channels, this->got.format, this->got.samples, this->sameFormat ? 1 : 0,
+				statsMs, this->statsWrites, this->statsInBytes, expectedIn, this->statsOutBytes, this->statsSilenceBytes, this->statsBlocks, this->statsPartialWrites, this->statsLowQueue,
+				minQueueMs, maxQueueMs, sdlQueueMs, sdlQueueBytes, this->statsMaxWriteGap, this->statsConvertMs);
+			this->lastStatsTime = now;
+			this->statsWrites = 0;
+			this->statsBlocks = 0;
+			this->statsPartialWrites = 0;
+			this->statsLowQueue = 0;
+			this->statsMaxWriteGap = 0;
+			this->statsMinQueueWant = 0xFFFFFFFF;
+			this->statsMaxQueueWant = 0;
+			this->statsInBytes = 0;
+			this->statsOutBytes = 0;
+			this->statsSilenceBytes = 0;
+			this->statsConvertMs = 0;
+		}
+	}
+
+	void recordAudioBlock(U32 queuedBefore) {
+		this->statsBlocks++;
+		this->statsMinQueueWant = std::min(this->statsMinQueueWant, queuedBefore);
+		this->statsMaxQueueWant = std::max(this->statsMaxQueueWant, queuedBefore);
+		U32 now = KSystem::getMilliesSinceStart();
+		if (!this->lastStatsTime) {
+			this->lastStatsTime = now;
+		}
+		if (now - this->lastStatsTime >= 1000) {
+			recordAudioStats(queuedBefore, queuedBefore, 0, 0, 0, 0);
+		}
+	}
+#endif
 };
 
 // Voices whose closeAudio was called while audio was still queued to SDL.
@@ -260,6 +422,29 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 		return 0;
 	}
 
+	U32 queued = this->getGuestQueuedAudioSizeWant();
+	if (queued >= DSP_BUFFER_SIZE) {
+#ifdef BOXEDWINE_AUDIO_DEBUG
+		recordAudioBlock(queued);
+#endif
+		return -K_EWOULDBLOCK;
+	}
+	U32 blockSize = bytesPerSampleWant() * want.channels;
+#ifdef BOXEDWINE_AUDIO_DEBUG
+	U32 requestedLen = len;
+#endif
+	len = std::min(len, (DSP_BUFFER_SIZE - queued) & ~(blockSize - 1));
+	if (!len) {
+#ifdef BOXEDWINE_AUDIO_DEBUG
+		recordAudioBlock(queued);
+#endif
+		return -K_EWOULDBLOCK;
+	}
+
+#ifdef BOXEDWINE_AUDIO_DEBUG
+	U32 queuedLen = len;
+	U32 convertMs = 0;
+#endif
 	if (!this->sameFormat) {
 		int needed = (int)len * this->cvt.len_mult;
 		if (this->cvtBufLen && this->cvtBufLen < needed) {
@@ -274,11 +459,25 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 		this->cvt.len = (int)len;
 		this->cvt.buf = this->cvtBuf;
 		memcpy(this->cvt.buf, data, len);
+#ifdef BOXEDWINE_AUDIO_DEBUG
+		U32 convertStart = KSystem::getMilliesSinceStart();
+#endif
 		SDL_ConvertAudio(&this->cvt);
+#ifdef BOXEDWINE_AUDIO_DEBUG
+		convertMs = KSystem::getMilliesSinceStart() - convertStart;
+		queuedLen = this->cvt.len_cvt;
+#endif
 		SDL_QueueAudio(this->deviceId, this->cvt.buf, this->cvt.len_cvt);
 	} else {
 		SDL_QueueAudio(this->deviceId, data, len);
 	}
+	addRealQueuedWant(len);
+#ifdef BOXEDWINE_AUDIO_DEBUG
+	this->statsSilenceBytes += topUpSilence();
+	recordAudioStats(queued, this->getGuestQueuedAudioSizeWant(), requestedLen, len, queuedLen, convertMs);
+#else
+	topUpSilence();
+#endif
 	return len;
 }
 

--- a/platform/sdl/kdspaudio.cpp
+++ b/platform/sdl/kdspaudio.cpp
@@ -139,21 +139,6 @@ public:
 	bool open = false;
 	std::deque<U8> audioBuffer; // only used when KSystem::soundEnabled is false
 	SDL_AudioDeviceID deviceId = 0;
-#ifdef BOXEDWINE_AUDIO_DEBUG
-	U32 lastStatsTime = 0;
-	U32 lastWriteTime = 0;
-	U32 statsWrites = 0;
-	U32 statsBlocks = 0;
-	U32 statsPartialWrites = 0;
-	U32 statsLowQueue = 0;
-	U32 statsMaxWriteGap = 0;
-	U32 statsMinQueueWant = 0xFFFFFFFF;
-	U32 statsMaxQueueWant = 0;
-	U32 statsInBytes = 0;
-	U32 statsOutBytes = 0;
-	U32 statsSilenceBytes = 0;
-	U32 statsConvertMs = 0;
-#endif
 	U32 realQueuedWant = 0;
 	U32 lastRealQueuedTime = 0;
 	std::vector<U8> silenceBuffer;
@@ -207,70 +192,6 @@ public:
 		return 0;
 #endif
 	}
-
-#ifdef BOXEDWINE_AUDIO_DEBUG
-	void recordAudioStats(U32 queuedBefore, U32 queuedAfter, U32 requestedLen, U32 acceptedLen, U32 queuedLen, U32 convertMs) {
-		U32 now = KSystem::getMilliesSinceStart();
-		if (!this->lastStatsTime) {
-			this->lastStatsTime = now;
-		}
-		if (this->lastWriteTime) {
-			this->statsMaxWriteGap = std::max(this->statsMaxWriteGap, now - this->lastWriteTime);
-		}
-		this->lastWriteTime = now;
-		this->statsWrites++;
-		this->statsInBytes += acceptedLen;
-		this->statsOutBytes += queuedLen;
-		this->statsConvertMs += convertMs;
-		if (acceptedLen < requestedLen) {
-			this->statsPartialWrites++;
-		}
-		this->statsMinQueueWant = std::min(this->statsMinQueueWant, queuedBefore);
-		this->statsMaxQueueWant = std::max(this->statsMaxQueueWant, queuedAfter);
-		if (queuedBefore < this->dspFragSize) {
-			this->statsLowQueue++;
-		}
-		if (now - this->lastStatsTime >= 1000) {
-			U32 statsMs = now - this->lastStatsTime;
-			U32 wantBytesPerSecond = bytesPerSecondWant();
-			U32 gotBytesPerSecond = bytesPerSecondGot();
-			U32 minQueueMs = wantBytesPerSecond ? (U32)(((U64)this->statsMinQueueWant * 1000) / wantBytesPerSecond) : 0;
-			U32 maxQueueMs = wantBytesPerSecond ? (U32)(((U64)this->statsMaxQueueWant * 1000) / wantBytesPerSecond) : 0;
-			U32 sdlQueueBytes = this->deviceId ? SDL_GetQueuedAudioSize(this->deviceId) : 0;
-			U32 sdlQueueMs = gotBytesPerSecond ? (U32)(((U64)sdlQueueBytes * 1000) / gotBytesPerSecond) : 0;
-			U32 expectedIn = (U32)(((U64)wantBytesPerSecond * statsMs) / 1000);
-			klog_fmt("audioStats: id=%d want=%d/%d/%x got=%d/%d/%x samples=%d same=%d ms=%d writes=%d in=%d expectIn=%d out=%d silence=%d block=%d partial=%d low=%d qWantMs=%d..%d qSdl=%dms/%dB gapMax=%dms cvtMs=%d",
-				this->id, this->want.freq, this->want.channels, this->want.format, this->got.freq, this->got.channels, this->got.format, this->got.samples, this->sameFormat ? 1 : 0,
-				statsMs, this->statsWrites, this->statsInBytes, expectedIn, this->statsOutBytes, this->statsSilenceBytes, this->statsBlocks, this->statsPartialWrites, this->statsLowQueue,
-				minQueueMs, maxQueueMs, sdlQueueMs, sdlQueueBytes, this->statsMaxWriteGap, this->statsConvertMs);
-			this->lastStatsTime = now;
-			this->statsWrites = 0;
-			this->statsBlocks = 0;
-			this->statsPartialWrites = 0;
-			this->statsLowQueue = 0;
-			this->statsMaxWriteGap = 0;
-			this->statsMinQueueWant = 0xFFFFFFFF;
-			this->statsMaxQueueWant = 0;
-			this->statsInBytes = 0;
-			this->statsOutBytes = 0;
-			this->statsSilenceBytes = 0;
-			this->statsConvertMs = 0;
-		}
-	}
-
-	void recordAudioBlock(U32 queuedBefore) {
-		this->statsBlocks++;
-		this->statsMinQueueWant = std::min(this->statsMinQueueWant, queuedBefore);
-		this->statsMaxQueueWant = std::max(this->statsMaxQueueWant, queuedBefore);
-		U32 now = KSystem::getMilliesSinceStart();
-		if (!this->lastStatsTime) {
-			this->lastStatsTime = now;
-		}
-		if (now - this->lastStatsTime >= 1000) {
-			recordAudioStats(queuedBefore, queuedBefore, 0, 0, 0, 0);
-		}
-	}
-#endif
 };
 
 // Voices whose closeAudio was called while audio was still queued to SDL.
@@ -438,27 +359,14 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 
 	U32 queued = this->getGuestQueuedAudioSizeWant();
 	if (queued >= DSP_BUFFER_SIZE) {
-#ifdef BOXEDWINE_AUDIO_DEBUG
-		recordAudioBlock(queued);
-#endif
 		return -K_EWOULDBLOCK;
 	}
 	U32 blockSize = bytesPerSampleWant() * want.channels;
-#ifdef BOXEDWINE_AUDIO_DEBUG
-	U32 requestedLen = len;
-#endif
 	len = std::min(len, (DSP_BUFFER_SIZE - queued) & ~(blockSize - 1));
 	if (!len) {
-#ifdef BOXEDWINE_AUDIO_DEBUG
-		recordAudioBlock(queued);
-#endif
 		return -K_EWOULDBLOCK;
 	}
 
-#ifdef BOXEDWINE_AUDIO_DEBUG
-	U32 queuedLen = len;
-	U32 convertMs = 0;
-#endif
 	if (!this->sameFormat) {
 		int needed = (int)len * this->cvt.len_mult;
 		if (this->cvtBufLen && this->cvtBufLen < needed) {
@@ -473,25 +381,13 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 		this->cvt.len = (int)len;
 		this->cvt.buf = this->cvtBuf;
 		memcpy(this->cvt.buf, data, len);
-#ifdef BOXEDWINE_AUDIO_DEBUG
-		U32 convertStart = KSystem::getMilliesSinceStart();
-#endif
 		SDL_ConvertAudio(&this->cvt);
-#ifdef BOXEDWINE_AUDIO_DEBUG
-		convertMs = KSystem::getMilliesSinceStart() - convertStart;
-		queuedLen = this->cvt.len_cvt;
-#endif
 		SDL_QueueAudio(this->deviceId, this->cvt.buf, this->cvt.len_cvt);
 	} else {
 		SDL_QueueAudio(this->deviceId, data, len);
 	}
 	addRealQueuedWant(len);
-#ifdef BOXEDWINE_AUDIO_DEBUG
-	this->statsSilenceBytes += topUpSilence();
-	recordAudioStats(queued, this->getGuestQueuedAudioSizeWant(), requestedLen, len, queuedLen, convertMs);
-#else
 	topUpSilence();
-#endif
 	return len;
 }
 

--- a/project/emscripten/boxedwine-shell.js
+++ b/project/emscripten/boxedwine-shell.js
@@ -10,6 +10,7 @@
         let DEFAULT_APP_DIRECTORY = "/home/username/.wine/dosdevices/c:/files";
         let DEFAULT_BPP = 32;
         let DEFAULT_FRAME_SKIP = "0";
+        let DEFAULT_AUDIO_FREQ = 11025;
         let DEFAULT_ROOT_ZIP_FILE = "boxedwine.zip";
         //params
         let Config = {};
@@ -44,6 +45,7 @@
             Config.extraPayload = getPayload("overlay-payload"); 
             Config.Program = getExecutable(); //MANUAL:"CHOMP.EXE";
             Config.isSoundEnabled = getSound();
+            Config.audioFreq = getAudioFreq();
             Config.disableHideCursor = getDisableHideCursor();
             Config.bpp = getBitsPerPixel();
 			Config.cpu = getCPU();
@@ -242,6 +244,21 @@
             }
             console.log("setting sound to: "+soundEnabled);
             return soundEnabled;
+        }
+
+        function getAudioFreq() {
+            var audioFreq = getParameter("audioFreq");
+            if (!allowParameterOverride()) {
+                audioFreq = DEFAULT_AUDIO_FREQ;
+            } else if (audioFreq == "22050") {
+                audioFreq = 22050;
+            } else if (audioFreq == "11025" || audioFreq == "") {
+                audioFreq = DEFAULT_AUDIO_FREQ;
+            } else {
+                audioFreq = DEFAULT_AUDIO_FREQ;
+            }
+            console.log("setting audioFreq to: " + audioFreq);
+            return audioFreq;
         }
 
         function getDisableHideCursor() {
@@ -659,6 +676,10 @@
             
             if(!Config.isSoundEnabled){
                 params.push("-nosound");
+            }
+            if(Config.audioFreq != DEFAULT_AUDIO_FREQ){
+                params.push("-audioFreq");
+                params.push("" + Config.audioFreq);
             }
             if (Config.disableHideCursor) {
                 params.push("-disableHideCursor");

--- a/project/emscripten/makefile
+++ b/project/emscripten/makefile
@@ -101,7 +101,8 @@ $(OBJS): INCLUDES := -I../../lib/asmjit -I../../include -I../../lib/simde
 $(SOFT_OBJS): INCLUDES := -I../../lib/softfloat/source/include -I../../lib/softfloat/source -I../../lib/softfloat/source/8086-SSE
 
 CXXFLAGS ?= -std=c++20
-CPPFLAGS ?= -O3 -s USE_SDL=2 -s USE_ZLIB=1 -DBOXEDWINE_ZLIB -DSDL2=1 -DBOXEDWINE_DISABLE_UI -DSIMDE_SSE2_NO_NATIVE $(GCC_EXTRA_FLAGS) -Wall -Wno-deprecated-pragma -Wno-format-security -Wno-unused-private-field -Wno-invalid-offsetof -Wno-delete-incomplete -Wno-unused-result -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable -mtail-call $(INCLUDES) $(EXTRA_CPP_FLAGS)
+AUDIO_DEBUG_FLAGS := $(if $(filter 1 true TRUE yes YES,$(AUDIO_DEBUG)),-DBOXEDWINE_AUDIO_DEBUG=1,)
+CPPFLAGS ?= -O3 -s USE_SDL=2 -s USE_ZLIB=1 -DBOXEDWINE_ZLIB -DSDL2=1 -DBOXEDWINE_DISABLE_UI -DSIMDE_SSE2_NO_NATIVE $(AUDIO_DEBUG_FLAGS) $(GCC_EXTRA_FLAGS) -Wall -Wno-deprecated-pragma -Wno-format-security -Wno-unused-private-field -Wno-invalid-offsetof -Wno-delete-incomplete -Wno-unused-result -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable -mtail-call $(INCLUDES) $(EXTRA_CPP_FLAGS)
 
 SHELL_LDFLAGS := $(if $(filter %.html,$(TARGET_EXEC)),--shell-file $(SHELL_FILE),)
 LDFLAGS = -s FORCE_FILESYSTEM -lidbfs.js -s USE_SDL=2 -s USE_ZLIB=1 -fwasm-exceptions -s INITIAL_MEMORY=536870912 $(SHELL_LDFLAGS) -s EXPORTED_RUNTIME_METHODS='["addRunDependency", "removeRunDependency","ERRNO_CODES","ccall","FS"]' -mtail-call $(EXTRA_LD_FLAGS)

--- a/project/emscripten/makefile
+++ b/project/emscripten/makefile
@@ -101,8 +101,7 @@ $(OBJS): INCLUDES := -I../../lib/asmjit -I../../include -I../../lib/simde
 $(SOFT_OBJS): INCLUDES := -I../../lib/softfloat/source/include -I../../lib/softfloat/source -I../../lib/softfloat/source/8086-SSE
 
 CXXFLAGS ?= -std=c++20
-AUDIO_DEBUG_FLAGS := $(if $(filter 1 true TRUE yes YES,$(AUDIO_DEBUG)),-DBOXEDWINE_AUDIO_DEBUG=1,)
-CPPFLAGS ?= -O3 -s USE_SDL=2 -s USE_ZLIB=1 -DBOXEDWINE_ZLIB -DSDL2=1 -DBOXEDWINE_DISABLE_UI -DSIMDE_SSE2_NO_NATIVE $(AUDIO_DEBUG_FLAGS) $(GCC_EXTRA_FLAGS) -Wall -Wno-deprecated-pragma -Wno-format-security -Wno-unused-private-field -Wno-invalid-offsetof -Wno-delete-incomplete -Wno-unused-result -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable -mtail-call $(INCLUDES) $(EXTRA_CPP_FLAGS)
+CPPFLAGS ?= -O3 -s USE_SDL=2 -s USE_ZLIB=1 -DBOXEDWINE_ZLIB -DSDL2=1 -DBOXEDWINE_DISABLE_UI -DSIMDE_SSE2_NO_NATIVE $(GCC_EXTRA_FLAGS) -Wall -Wno-deprecated-pragma -Wno-format-security -Wno-unused-private-field -Wno-invalid-offsetof -Wno-delete-incomplete -Wno-unused-result -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable -mtail-call $(INCLUDES) $(EXTRA_CPP_FLAGS)
 
 SHELL_LDFLAGS := $(if $(filter %.html,$(TARGET_EXEC)),--shell-file $(SHELL_FILE),)
 LDFLAGS = -s FORCE_FILESYSTEM -lidbfs.js -s USE_SDL=2 -s USE_ZLIB=1 -fwasm-exceptions -s INITIAL_MEMORY=536870912 $(SHELL_LDFLAGS) -s EXPORTED_RUNTIME_METHODS='["addRunDependency", "removeRunDependency","ERRNO_CODES","ccall","FS"]' -mtail-call $(EXTRA_LD_FLAGS)

--- a/source/kernel/devs/devdsp.cpp
+++ b/source/kernel/devs/devdsp.cpp
@@ -27,10 +27,10 @@
 #include "kdspaudio.h"
 
 #ifdef __EMSCRIPTEN__
-static const U32 DSP_MAX_OUTPUT_FREQ = 11025;
+static U32 dspMaxOutputFreq = 11025;
 static const U32 DSP_DEFAULT_FRAGMENT_SIZE = 1024;
 #else
-static const U32 DSP_MAX_OUTPUT_FREQ = 48000;
+static U32 dspMaxOutputFreq = 48000;
 static const U32 DSP_DEFAULT_FRAGMENT_SIZE = 4096;
 #endif
 static const U32 DSP_DEFAULT_FRAGMENT_COUNT = 8;
@@ -71,6 +71,18 @@ private:
 
 void dspShutdown() {
     KDspAudio::shutdown();
+}
+
+void dspSetMaxOutputFreq(U32 freq) {
+#ifdef __EMSCRIPTEN__
+    if (freq == 11025 || freq == 22050) {
+        dspMaxOutputFreq = freq;
+    } else {
+        kwarn_fmt("Unsupported Emscripten audio frequency %d, using %d", freq, dspMaxOutputFreq);
+    }
+#else
+    dspMaxOutputFreq = freq;
+#endif
 }
 
 bool DevDsp::setLength(S64 len) {
@@ -134,7 +146,7 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
             kpanic("SNDCTL_DSP_SPEED was expecting a len of 4");
         }
 		U32 oldFreq = this->freq;
-		this->freq = std::min(memory->readd(IOCTL_ARG1), DSP_MAX_OUTPUT_FREQ);
+		this->freq = std::min(memory->readd(IOCTL_ARG1), dspMaxOutputFreq);
         if (oldFreq != this->freq) {
             this->audio->closeAudio();
         }
@@ -314,7 +326,7 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
             memory->writed(p, 1); p+=4; // int enabled;			/* 1=enabled, 0=device not ready at this moment */
             memory->writed(p, 0); p+=4; // int flags;			/* For internal use only - no practical meaning */
             memory->writed(p, 11025); p += 4; // int min_rate
-            memory->writed(p, DSP_MAX_OUTPUT_FREQ); p+=4; // max_rate;	/* Sample rate limits */
+            memory->writed(p, dspMaxOutputFreq); p+=4; // max_rate;	/* Sample rate limits */
             memory->writed(p, 1); p+=4; // int min_channels
             memory->writed(p, 2); p+=4; // max_channels;	/* Number of channels supported */
             memory->writed(p, 0); p+=4; // int binding;			/* DSP_BIND_FRONT, etc. 0 means undefined */

--- a/source/kernel/devs/devdsp.cpp
+++ b/source/kernel/devs/devdsp.cpp
@@ -28,9 +28,12 @@
 
 #ifdef __EMSCRIPTEN__
 static const U32 DSP_MAX_OUTPUT_FREQ = 11025;
+static const U32 DSP_DEFAULT_FRAGMENT_SIZE = 1024;
 #else
 static const U32 DSP_MAX_OUTPUT_FREQ = 48000;
+static const U32 DSP_DEFAULT_FRAGMENT_SIZE = 4096;
 #endif
+static const U32 DSP_DEFAULT_FRAGMENT_COUNT = 8;
 
 class DevDsp : public FsVirtualOpenNode {
 public:
@@ -39,6 +42,7 @@ public:
         this->freq = 11025;
         this->channels = 1;
         this->format = AFMT_U8;
+        this->audio->setFragmentSize(DSP_DEFAULT_FRAGMENT_SIZE);
     } 
     virtual ~DevDsp() {this->audio->closeAudio();}
 
@@ -48,11 +52,20 @@ public:
     U32 readNative(U8* buffer, U32 len) override;
     U32 writeNative(U8* buffer, U32 len) override;
     void waitForEvents(BOXEDWINE_CONDITION& parentCondition, U32 events) override;
+    bool isWriteReady() override;
 
     std::shared_ptr<KDspAudio> audio;
     U32 freq;
     U32 channels;
     U32 format;
+    U32 fragmentCount = DSP_DEFAULT_FRAGMENT_COUNT;
+    U32 bytesWritten = 0;
+    U32 lastOutputBlocks = 0;
+
+private:
+    U32 getEffectiveBufferCapacity();
+    U32 getUsedBufferSize();
+    U32 getAvailableBufferSize();
 };
 
 
@@ -72,7 +85,29 @@ U32 DevDsp::writeNative(U8* buffer, U32 len) {
     if (!this->audio->isOpen()) {
         this->audio->openAudio(this->format, this->freq, this->channels);
     }
-    return this->audio->writeAudio(buffer, len);
+    U32 result = this->audio->writeAudio(buffer, len);
+    if ((S32)result > 0) {
+        this->bytesWritten += result;
+    }
+    return result;
+}
+
+U32 DevDsp::getEffectiveBufferCapacity() {
+    U32 capacity = this->audio->getBufferCapacity();
+    U32 fragmentCapacity = this->audio->getFragmentSize() * this->fragmentCount;
+    return std::min(capacity, fragmentCapacity ? fragmentCapacity : capacity);
+}
+
+U32 DevDsp::getUsedBufferSize() {
+    return std::min(this->audio->getBufferSize(), this->getEffectiveBufferCapacity());
+}
+
+U32 DevDsp::getAvailableBufferSize() {
+    return this->getEffectiveBufferCapacity() - this->getUsedBufferSize();
+}
+
+bool DevDsp::isWriteReady() {
+    return this->getAvailableBufferSize() >= this->audio->getFragmentSize();
 }
 
 U32 DevDsp::ioctl(KThread* thread, U32 request) {
@@ -89,6 +124,10 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         this->freq = 8000;
         this->channels = 1;
         this->format = AFMT_U8;
+        this->audio->setFragmentSize(DSP_DEFAULT_FRAGMENT_SIZE);
+        this->fragmentCount = DSP_DEFAULT_FRAGMENT_COUNT;
+        this->bytesWritten = 0;
+        this->lastOutputBlocks = 0;
         return 0;
     case 0x5002: { // SNDCTL_DSP_SPEED 
         if (len!=4) {
@@ -184,10 +223,17 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
             memory->writed(IOCTL_ARG1, this->channels);
         return 0;
         }
-    case 0x500A: // SNDCTL_DSP_SETFRAGMENT
-		// this->data->dspFragSize = 1 << (readd(IOCTL_ARG1) & 0xFFFF);
-        klog("DevDsp::ioctl was not expecting SNDCTL_DSP_SETFRAGMENT");
+    case 0x500A: { // SNDCTL_DSP_SETFRAGMENT
+        U32 value = memory->readd(IOCTL_ARG1);
+        U32 shift = value & 0xFFFF;
+        U32 count = value >> 16;
+        if (shift > 15) {
+            shift = 15;
+        }
+        this->audio->setFragmentSize(1 << shift);
+        this->fragmentCount = std::clamp(count, (U32)2, (U32)64);
         return 0;
+    }
     case 0x500B: // SNDCTL_DSP_GETFMTS
         memory->writed(IOCTL_ARG1, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_LE | AFMT_U16_BE);
         return 0;
@@ -203,11 +249,11 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 
     case 0x500C: // SNDCTL_DSP_GETOSPACE
     {
-        U32 capacity = this->audio->getBufferCapacity();
-        U32 used = std::min(this->audio->getBufferSize(), capacity);
+        U32 capacity = this->getEffectiveBufferCapacity();
+        U32 used = this->getUsedBufferSize();
         U32 available = capacity - used;
         memory->writed(IOCTL_ARG1, available / this->audio->getFragmentSize()); // fragments
-        memory->writed(IOCTL_ARG1 + 4, this->audio->getBufferCapacity() / this->audio->getFragmentSize());
+        memory->writed(IOCTL_ARG1 + 4, capacity / this->audio->getFragmentSize());
         memory->writed(IOCTL_ARG1 + 8, this->audio->getFragmentSize());
         memory->writed(IOCTL_ARG1 + 12, available);
         return 0;
@@ -233,33 +279,21 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         */
         klog("DevDsp::ioctl was not expecting SNDCTL_DSP_SETTRIGGER");
         return 0;
-    case 0x5012: // SNDCTL_DSP_GETOPTR
-        /*
-        writed(IOCTL_ARG1, 0); // Total # of bytes processed
-        writed(IOCTL_ARG1 + 4, 0); // # of fragment transitions since last time
-        if (data->pauseEnabled()) {
-			writed(IOCTL_ARG1 + 8, this->data->pauseAtLen); // Current DMA pointer value
-			if (this->data->pauseAtLen == 0) {
-                if (sdlSoundEnabled) {
-                    SDL_PauseAudio(0);
-                }
-            }
-        } else {
-			writed(IOCTL_ARG1 + 8, (U32)audioBuffer.size()); // Current DMA pointer value
-        }
-        */
-        klog("DevDsp::ioctl was not expecting SNDCTL_DSP_GETOPTR");
+    case 0x5012: { // SNDCTL_DSP_GETOPTR
+        U32 fragmentSize = this->audio->getFragmentSize();
+        U32 currentBlocks = fragmentSize ? this->bytesWritten / fragmentSize : 0;
+        U32 blocks = currentBlocks - this->lastOutputBlocks;
+        this->lastOutputBlocks = currentBlocks;
+        U32 capacity = this->getEffectiveBufferCapacity();
+        memory->writed(IOCTL_ARG1, this->bytesWritten); // Total # of bytes written
+        memory->writed(IOCTL_ARG1 + 4, blocks); // # of fragment transitions since last time
+        memory->writed(IOCTL_ARG1 + 8, capacity ? this->bytesWritten % capacity : 0); // Current DMA pointer value
         return 0;
+    }
     case 0x5016: // SNDCTL_DSP_SETDUPLEX
         return -K_EINVAL;
-    case 0x5017: // SNDCTL_DSP_GETODELAY 
-        /*
-        if (write) {
-			writed(IOCTL_ARG1, (U32)audioBuffer.size());
-            return 0;
-        }
-        */
-        klog("DevDsp::ioctl was not expecting SNDCTL_DSP_GETODELAY");
+    case 0x5017: // SNDCTL_DSP_GETODELAY
+        memory->writed(IOCTL_ARG1, this->getUsedBufferSize());
         return 0;
     case 0x580C: // SNDCTL_ENGINEINFO
         if (write) {
@@ -304,8 +338,9 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 
 void DevDsp::waitForEvents(BOXEDWINE_CONDITION& parentCondition, U32 events) {
     if (events & K_POLLOUT) {
-        // BOXEDWINE_CONDITION_ADD_CHILD_CONDITION(parentCondition, this->data->bufferCond, nullptr);
-        klog("DevDsp::waitForEvents POLLOUT not implemented");
+        if (this->isWriteReady()) {
+            BOXEDWINE_CONDITION_SIGNAL_ALL(parentCondition);
+        }
     }
 }
 

--- a/source/kernel/devs/devdsp.cpp
+++ b/source/kernel/devs/devdsp.cpp
@@ -21,9 +21,16 @@
 #include "kscheduler.h"
 #include "../../io/fsvirtualopennode.h"
 #include "oss.h"
+#include <algorithm>
 #include <math.h>
 #include <string.h>
 #include "kdspaudio.h"
+
+#ifdef __EMSCRIPTEN__
+static const U32 DSP_MAX_OUTPUT_FREQ = 11025;
+#else
+static const U32 DSP_MAX_OUTPUT_FREQ = 48000;
+#endif
 
 class DevDsp : public FsVirtualOpenNode {
 public:
@@ -83,17 +90,19 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         this->channels = 1;
         this->format = AFMT_U8;
         return 0;
-    case 0x5002:  // SNDCTL_DSP_SPEED 
+    case 0x5002: { // SNDCTL_DSP_SPEED 
         if (len!=4) {
             kpanic("SNDCTL_DSP_SPEED was expecting a len of 4");
         }
-		this->freq = memory->readd(IOCTL_ARG1);
-        if (freq != this->freq) {
+		U32 oldFreq = this->freq;
+		this->freq = std::min(memory->readd(IOCTL_ARG1), DSP_MAX_OUTPUT_FREQ);
+        if (oldFreq != this->freq) {
             this->audio->closeAudio();
         }
 		if (write)
             memory->writed(IOCTL_ARG1, this->freq);
         return 0;
+    }
     case 0x5003: { // SNDCTL_DSP_STEREO
         if (len!=4) {
             kpanic("SNDCTL_DSP_STEREO was expecting a len of 4");
@@ -149,7 +158,7 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 			this->format = AFMT_U8;
             break;
         case AFMT_FLOAT:
-            this->format = AFMT_FLOAT;
+            this->format = AFMT_S16_LE;
             break;
         }
         if (write)
@@ -180,7 +189,7 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         klog("DevDsp::ioctl was not expecting SNDCTL_DSP_SETFRAGMENT");
         return 0;
     case 0x500B: // SNDCTL_DSP_GETFMTS
-        memory->writed(IOCTL_ARG1, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_LE | AFMT_U16_BE | AFMT_FLOAT);
+        memory->writed(IOCTL_ARG1, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_LE | AFMT_U16_BE);
         return 0;
 
 		//typedef struct audio_buf_info {
@@ -194,11 +203,13 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 
     case 0x500C: // SNDCTL_DSP_GETOSPACE
     {
-        // I'm not sure why bytes works better as getBufferCapacity instead of getBufferCapacity - getBufferSize, but mac stutters a lot otherwise
-        memory->writed(IOCTL_ARG1, this->audio->getBufferCapacity() / this->audio->getFragmentSize()); // fragments
+        U32 capacity = this->audio->getBufferCapacity();
+        U32 used = std::min(this->audio->getBufferSize(), capacity);
+        U32 available = capacity - used;
+        memory->writed(IOCTL_ARG1, available / this->audio->getFragmentSize()); // fragments
         memory->writed(IOCTL_ARG1 + 4, this->audio->getBufferCapacity() / this->audio->getFragmentSize());
         memory->writed(IOCTL_ARG1 + 8, this->audio->getFragmentSize());
-        memory->writed(IOCTL_ARG1 + 12, this->audio->getBufferCapacity());
+        memory->writed(IOCTL_ARG1 + 12, available);
         return 0;
     }
     case 0x500F: // SNDCTL_DSP_GETCAPS
@@ -259,7 +270,7 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
             memory->writed(p, -1); p+=4; // int pid;
             memory->writed(p, PCM_CAP_OUTPUT); p+=4; // int caps;			/* PCM_CAP_INPUT, PCM_CAP_OUTPUT */
             memory->writed(p, 0); p+=4; // int iformats
-            memory->writed(p, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_BE | AFMT_FLOAT); p+=4; // int oformats;
+            memory->writed(p, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_BE); p+=4; // int oformats;
             memory->writed(p, 0); p+=4; // int magic;			/* Reserved for internal use */
             memory->strcpy(p, ""); p+=64; // oss_cmd_t cmd;		/* Command using the device (if known) */
             memory->writed(p, 0); p+=4; // int card_number;
@@ -269,7 +280,7 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
             memory->writed(p, 1); p+=4; // int enabled;			/* 1=enabled, 0=device not ready at this moment */
             memory->writed(p, 0); p+=4; // int flags;			/* For internal use only - no practical meaning */
             memory->writed(p, 11025); p += 4; // int min_rate
-            memory->writed(p, 48000); p+=4; // max_rate;	/* Sample rate limits */
+            memory->writed(p, DSP_MAX_OUTPUT_FREQ); p+=4; // max_rate;	/* Sample rate limits */
             memory->writed(p, 1); p+=4; // int min_channels
             memory->writed(p, 2); p+=4; // max_channels;	/* Number of channels supported */
             memory->writed(p, 0); p+=4; // int binding;			/* DSP_BIND_FRONT, etc. 0 means undefined */

--- a/source/kernel/kscheduler.cpp
+++ b/source/kernel/kscheduler.cpp
@@ -139,6 +139,20 @@ S32 contextTimeRemaining = DEFAULT_CONTEXT_TIME;
 int count;
 extern struct Block emptyBlock;
 
+static S32 decreaseContextTime(S32 value) {
+    if (value <= MIN_CONTEXT_TIME + CONTEXT_TIME_STEP) {
+        return MIN_CONTEXT_TIME;
+    }
+    return value - CONTEXT_TIME_STEP;
+}
+
+static S32 increaseContextTime(S32 value) {
+    if (value >= MAX_CONTEXT_TIME - CONTEXT_TIME_STEP) {
+        return MAX_CONTEXT_TIME;
+    }
+    return value + CONTEXT_TIME_STEP;
+}
+
 void runThreadSlice(KThread* thread) {
     CPU* cpu;
 
@@ -227,13 +241,9 @@ bool runSlice() {
     }
     if (!scheduledThreads.isEmpty()) {
         if (elapsedTime>11000) {
-            if (contextTime > MIN_CONTEXT_TIME) {
-                contextTime -= CONTEXT_TIME_STEP;
-            }
+            contextTime = decreaseContextTime(contextTime);
         } else if (elapsedTime<9500) {
-            if (contextTime < MAX_CONTEXT_TIME) {
-                contextTime += CONTEXT_TIME_STEP;
-            }
+            contextTime = increaseContextTime(contextTime);
         }
     }
     //klog("ran slice in %dus %d", (U32)elapsedTime, contextTime);    

--- a/source/kernel/kscheduler.cpp
+++ b/source/kernel/kscheduler.cpp
@@ -123,8 +123,19 @@ void terminateCurrentThread(KThread* thread) {
 	unscheduleThread(thread);
 }
 
-S32 contextTime = 100000;
-S32 contextTimeRemaining = 100000;
+#ifdef __EMSCRIPTEN__
+static const S32 DEFAULT_CONTEXT_TIME = 10000;
+static const S32 MIN_CONTEXT_TIME = 2000;
+static const S32 MAX_CONTEXT_TIME = 10000;
+static const S32 CONTEXT_TIME_STEP = 1000;
+#else
+static const S32 DEFAULT_CONTEXT_TIME = 100000;
+static const S32 MIN_CONTEXT_TIME = 100000;
+static const S32 MAX_CONTEXT_TIME = 0x7FFFFFFF;
+static const S32 CONTEXT_TIME_STEP = 20000;
+#endif
+S32 contextTime = DEFAULT_CONTEXT_TIME;
+S32 contextTimeRemaining = DEFAULT_CONTEXT_TIME;
 int count;
 extern struct Block emptyBlock;
 
@@ -216,10 +227,13 @@ bool runSlice() {
     }
     if (!scheduledThreads.isEmpty()) {
         if (elapsedTime>11000) {
-            if (contextTime>100000)
-                contextTime-=20000;
+            if (contextTime > MIN_CONTEXT_TIME) {
+                contextTime -= CONTEXT_TIME_STEP;
+            }
         } else if (elapsedTime<9500) {
-            contextTime+=20000;
+            if (contextTime < MAX_CONTEXT_TIME) {
+                contextTime += CONTEXT_TIME_STEP;
+            }
         }
     }
     //klog("ran slice in %dus %d", (U32)elapsedTime, contextTime);    

--- a/source/sdl/emscripten/mainloop.cpp
+++ b/source/sdl/emscripten/mainloop.cpp
@@ -86,12 +86,17 @@ void waitForProcessToFinish(const std::shared_ptr<KProcess>& process, KThread* t
 #else
 
 static U32 lastTitleUpdate = 0;
+static bool mainLoopTimingConfigured = false;
 
 bool isMainthread() {
     return true;
 }
 
 void mainloop() {
+    if (!mainLoopTimingConfigured) {
+        emscripten_set_main_loop_timing(EM_TIMING_SETTIMEOUT, 1);
+        mainLoopTimingConfigured = true;
+    }
     U64 startTime = KSystem::getMicroCounter();
     U32 t;
     U32 count=0;
@@ -137,9 +142,6 @@ bool doMainLoop() {
             //SDL.defaults.opaqueFrontBuffer = false;
     );
     emscripten_set_main_loop(mainloop, 0, 1);
-#ifndef BOXEDWINE_MULTI_THREADED
-    emscripten_set_main_loop_timing(EM_TIMING_SETTIMEOUT, 1);
-#endif
     return false;
 }
 #endif

--- a/source/sdl/emscripten/mainloop.cpp
+++ b/source/sdl/emscripten/mainloop.cpp
@@ -137,6 +137,9 @@ bool doMainLoop() {
             //SDL.defaults.opaqueFrontBuffer = false;
     );
     emscripten_set_main_loop(mainloop, 0, 1);
+#ifndef BOXEDWINE_MULTI_THREADED
+    emscripten_set_main_loop_timing(EM_TIMING_SETTIMEOUT, 1);
+#endif
     return false;
 }
 #endif

--- a/source/sdl/startupArgs.cpp
+++ b/source/sdl/startupArgs.cpp
@@ -561,6 +561,9 @@ bool StartUpArgs::apply() {
         }
     }
     KSystem::videoOption = this->videoOption;
+    if (this->audioFreq) {
+        dspSetMaxOutputFreq(this->audioFreq);
+    }
     KSystem::soundEnabled = this->soundEnabled;
 #ifdef __EMSCRIPTEN__
     if (KSystem::soundEnabled) {
@@ -692,6 +695,14 @@ bool StartUpArgs::parseStartupArgs(int argc, const char **argv) {
             this->workingDirSet = true;
         } else if (!strcmp(argv[i], "-nosound")) {
 			this->soundEnabled = false;
+        } else if (!strcmp(argv[i], "-audioFreq") && i+1<argc) {
+            U32 audioFreq = atoi(argv[i+1]);
+            if (audioFreq == 11025 || audioFreq == 22050) {
+                this->audioFreq = audioFreq;
+            } else {
+                klog("-audioFreq must be 11025 or 22050");
+            }
+            i++;
         } else if (!strcmp(argv[i], "-novideo")) {
 #ifdef BOXEDWINE_MSVC
             this->videoOption = VIDEO_HIDE_WINDOW;

--- a/source/sdl/startupArgs.h
+++ b/source/sdl/startupArgs.h
@@ -94,6 +94,7 @@ public:
     int effectiveGroupId = GID;
 
     bool soundEnabled = true;
+    U32 audioFreq = 0;
     VideoOption videoOption = VIDEO_NORMAL;
     U32 vsync = VSYNC_DEFAULT;
     bool dpiAware = false;


### PR DESCRIPTION
Various improvements to aid audio playback from emscripten build.
With these changes audio is much cleaner on both single-threaded and multi-threaded builds.

New -audioFreq param. set to 11025 (default) or 22050

Combined with the scaling, mouse lock and recent performance work - Quake 2 runs well with audioFreq=22050 and resolution=640x480 in multi-threaded build.
To feed the audio samples quicker in the single threaded build the scheduler context time was modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable audio frequency (11025 Hz, 22050 Hz) via URL parameter and command-line
  * Runtime controls for max output frequency and audio fragment size
  * Dynamic fragment sizing and queue estimation for smoother audio playback

* **Bug Fixes**
  * Improved audio buffer reporting, write readiness, and backpressure handling
  * More reliable audio open/close and format advertising

* **Other**
  * Adjusted main-loop and scheduler timing for Emscripten builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danoon2/Boxedwine/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->