### PR TITLE
Emscripten - sdl audio split

### DIFF
--- a/include/devdsp.h
+++ b/include/devdsp.h
@@ -21,5 +21,7 @@
 
 FsOpenNode* openDevDsp(const std::shared_ptr<FsNode>& node, U32 flags, U32 data);
 void dspShutdown();
+#ifdef __EMSCRIPTEN__
 void dspSetMaxOutputFreq(U32 freq);
+#endif
 #endif

--- a/platform/sdl/kdspaudio.cpp
+++ b/platform/sdl/kdspaudio.cpp
@@ -24,6 +24,19 @@
 
 #define DSP_BUFFER_SIZE (1024*32)
 
+#ifndef __EMSCRIPTEN__
+static bool sdlAudioOpen;
+static U8 sdlSilence;
+
+static void closeSdlAudio() {
+	if (sdlAudioOpen) {
+		sdlAudioOpen = false;
+		SDL_PauseAudio(1);
+		SDL_CloseAudio();
+	}
+}
+#endif
+
 class KDspAudioSdl : public KDspAudio, public std::enable_shared_from_this<KDspAudioSdl> {
 public:
 	KDspAudioSdl() {
@@ -72,6 +85,11 @@ public:
 #endif
 	}
 	U32 getBufferCapacity() override { return DSP_BUFFER_SIZE;}
+
+#ifndef __EMSCRIPTEN__
+	void onClose();
+	void closeAudioFromAudioThread();
+#endif
 
 	U32 bytesPerSampleWant() {
 		return SDL_AUDIO_BITSIZE(this->want.format) / 8;
@@ -143,13 +161,19 @@ public:
 	SDL_AudioStream* stream = nullptr;
 	U32 openedFormat = 0;
 	int cvtBufLen = 0;
+#ifndef __EMSCRIPTEN__
+	int cvtBufPos = 0;
+#endif
 	unsigned char* cvtBuf = nullptr;
 	std::vector<U8> streamBuffer;
 	bool sameFormat = false;
 	U32 dspFragSize = 4096;
 	bool open = false;
-	std::deque<U8> audioBuffer; // only used when KSystem::soundEnabled is false
+	std::deque<U8> audioBuffer;
 	SDL_AudioDeviceID deviceId = 0;
+#ifndef __EMSCRIPTEN__
+	bool closeWhenDone = false;
+#endif
 	U32 realQueuedWant = 0;
 	U32 lastRealQueuedTime = 0;
 	std::vector<U8> silenceBuffer;
@@ -205,6 +229,79 @@ public:
 	}
 };
 
+#ifndef __EMSCRIPTEN__
+// Not really a voice; currently voices are not mixed.
+static std::list<std::shared_ptr<KDspAudioSdl>> voices;
+
+static void audioCallback(void* /*userdata*/, U8* stream, S32 len) {
+	if (!voices.size()) {
+		memset(stream, sdlSilence, len);
+		return;
+	}
+	std::shared_ptr<KDspAudioSdl> data = voices.front();
+	if (data->closeWhenDone && data->audioBuffer.size() == 0 && (data->cvtBufPos == 0 || data->cvtBufPos >= data->cvt.len_cvt)) {
+		data->closeAudioFromAudioThread();
+		memset(stream, sdlSilence, len);
+		return;
+	}
+
+	S32 available = (S32)data->audioBuffer.size();
+
+	if (!data->sameFormat) {
+		if (data->cvtBufPos < data->cvt.len_cvt) {
+			S32 todo = data->cvt.len_cvt - data->cvtBufPos;
+			if (todo > len) {
+				todo = len;
+			}
+			memcpy(stream, data->cvt.buf + data->cvtBufPos, todo);
+			data->cvtBufPos += todo;
+			stream += todo;
+			len -= todo;
+		}
+		if (len) {
+			data->cvt.len = available;
+			if (data->cvtBufLen && data->cvtBufLen < data->cvt.len * data->cvt.len_mult) {
+				data->cvtBufLen = 0;
+				SDL_free(data->cvtBuf);
+				data->cvtBuf = nullptr;
+			}
+			if (!data->cvtBufLen) {
+				data->cvtBufLen = data->cvt.len * data->cvt.len_mult;
+				data->cvtBuf = (Uint8*)SDL_malloc(data->cvt.len * data->cvt.len_mult);
+			}
+			data->cvt.buf = data->cvtBuf;
+
+			std::copy(data->audioBuffer.begin(), data->audioBuffer.begin() + available, data->cvt.buf);
+			data->audioBuffer.erase(data->audioBuffer.begin(), data->audioBuffer.begin() + available);
+
+			SDL_ConvertAudio(&data->cvt);
+			S32 todo = data->cvt.len_cvt;
+			if (todo > len) {
+				todo = len;
+			}
+			memcpy(stream, data->cvt.buf, todo);
+			stream += todo;
+			len -= todo;
+			data->cvtBufPos = todo;
+		}
+	} else {
+		if (available > len) {
+			available = len;
+		}
+		if (available) {
+			std::copy(data->audioBuffer.begin(), data->audioBuffer.begin() + available, stream);
+			data->audioBuffer.erase(data->audioBuffer.begin(), data->audioBuffer.begin() + available);
+			len -= available;
+			stream += available;
+		}
+	}
+	if (len) {
+		memset(stream, data->got.silence, len);
+	}
+}
+#endif
+
+#ifdef __EMSCRIPTEN__
 // Voices whose closeAudio was called while audio was still queued to SDL.
 // A timer polls these and finalizes the device close when the queue drains.
 static std::list<std::shared_ptr<KDspAudioSdl>> pendingCloses;
@@ -242,6 +339,7 @@ static void ensureDrainTimer() {
 		drainTimer = SDL_AddTimer(50, drainTimerCb, nullptr);
 	}
 }
+#endif
 
 void KDspAudioSdl::soundEnabled() {
 	if (this->open) {
@@ -250,18 +348,26 @@ void KDspAudioSdl::soundEnabled() {
 }
 
 void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
+#ifdef __EMSCRIPTEN__
 	this->want.callback = nullptr; // SDL_QueueAudio mode
 	this->want.userdata = nullptr;
+#else
+	this->want.callback = audioCallback;
+#endif
 	this->want.format = getSdlFormat(format);
 	this->want.freq = freq;
 	this->want.channels = channels;
 	this->openedFormat = format;
 
 	if (!KSystem::soundEnabled) {
+#ifndef __EMSCRIPTEN__
+		sdlAudioOpen = true;
+#endif
 		this->open = true;
 		return;
 	}
 
+#ifdef __EMSCRIPTEN__
 	{
 		BOXEDWINE_CRITICAL_SECTION_WITH_MUTEX(pendingClosesMutex);
 		// Drop any pending-close entry; we're reusing this voice.
@@ -283,6 +389,10 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
 			this->stream = nullptr;
 		}
 	}
+#else
+	// If the previous audio is still playing, it will get cut off. If I find a game that needs this, then perhaps I should think of a mixer.
+	closeSdlAudio();
+#endif
 
     SDL_AudioSpec requested = this->want;
 #ifdef __MACH__
@@ -290,12 +400,20 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
         requested.freq = 44100;
     }
 #endif
+#ifdef __EMSCRIPTEN__
 	SDL_AudioDeviceID newId = SDL_OpenAudioDevice(nullptr, 0, &requested, &this->got, SDL_AUDIO_ALLOW_ANY_CHANGE);
 	if (newId == 0) {
 		klog_fmt("Failed to open audio: %s", SDL_GetError());
 		return;
 	}
 	this->deviceId = newId;
+#else
+	if (SDL_OpenAudio(&requested, &this->got) < 0) {
+		klog_fmt("Failed to open audio: %s", SDL_GetError());
+	}
+	sdlSilence = this->got.silence;
+	sdlAudioOpen = true;
+#endif
 
 	if (this->want.freq != this->got.freq || this->want.channels != this->got.channels || this->want.format != this->got.format) {
 		this->sameFormat = false;
@@ -312,15 +430,49 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
 	}
 
 	this->open = true;	
+#ifdef __EMSCRIPTEN__
 	SDL_PauseAudioDevice(this->deviceId, 0);
+#else
+	voices.push_back(shared_from_this());
+	SDL_PauseAudio(0);
+	if (this->got.size) {
+		//this->dspFragSize = this->got.size;
+	}
+#endif
 	klog_fmt("openAudio: freq=%d(got %d) format=%x(got %x) channels=%d(got %d)", this->want.freq, this->got.freq, this->want.format, this->got.format, this->want.channels, this->got.channels);
 }
+
+#ifndef __EMSCRIPTEN__
+void KDspAudioSdl::closeAudioFromAudioThread() {
+	if (this->open) {
+		this->onClose();
+	}
+}
+#endif
 
 void KDspAudioSdl::closeAudio() {
 	if (!KSystem::soundEnabled) {
 		this->open = false;
 		return;
 	}
+#ifndef __EMSCRIPTEN__
+	if (this->open) {
+		bool needClose = true;
+		{
+			SDL_LockAudio();
+			if (audioBuffer.size() || (this->cvtBufPos != 0 && this->cvtBufPos < this->cvt.len_cvt)) {
+				closeWhenDone = true;
+				needClose = false;
+			}
+			SDL_UnlockAudio();
+		}
+		if (needClose) {
+			closeSdlAudio();
+			this->onClose();
+		}
+	}
+	return;
+#else
 	if (!this->open) {
 		return;
 	}
@@ -338,7 +490,28 @@ void KDspAudioSdl::closeAudio() {
 		SDL_CloseAudioDevice(this->deviceId);
 		this->deviceId = 0;
 	}
+#endif
 }
+
+#ifndef __EMSCRIPTEN__
+void KDspAudioSdl::onClose() {
+	if (!KSystem::soundEnabled) {
+		this->open = false;
+		return;
+	}
+	auto it = voices.begin();
+	while (it != voices.end()) {
+		std::shared_ptr<KDspAudioSdl> p = *it;
+		if (p == shared_from_this()) {
+			it = voices.erase(it);
+			break;
+		} else {
+			it++;
+		}
+	}
+	this->open = false;
+}
+#endif
 
 void KDspAudioSdl::setFragmentSize(U32 size) {
 #ifdef __EMSCRIPTEN__
@@ -353,12 +526,13 @@ void KDspAudioSdl::setFragmentSize(U32 size) {
 	this->dspFragSize = size ? size : blockSize;
 }
 
-U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {	
+U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
+	U32 wantBytesPerSecond = want.freq * want.channels * bytesPerSampleWant();
+	U32 delay = wantBytesPerSecond / 8;
+
 	if (!KSystem::soundEnabled) {
 		static U32 timeSinceLastWrite;
 
-		U32 wantBytesPerSecond = want.freq * want.channels * bytesPerSampleWant();
-		U32 delay = wantBytesPerSecond / 8;
 		U32 elapsedTime = KSystem::getMilliesSinceStart() - timeSinceLastWrite;
 		U32 bytesToRemove = wantBytesPerSecond * elapsedTime / 1000;
 
@@ -375,11 +549,25 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 		return len;
 	}
 
-	if (!this->open || !this->deviceId) {
+	if (!this->open) {
 		return 0;
 	}
 
-#ifdef __EMSCRIPTEN__
+#ifndef __EMSCRIPTEN__
+	SDL_LockAudio();
+	if (this->audioBuffer.size() > delay) {
+		SDL_UnlockAudio();
+		return -K_EWOULDBLOCK;
+	}
+	U32 blockSize = bytesPerSampleWant() * want.channels;
+	len = std::min(len, ((delay - (U32)this->audioBuffer.size()) & ~(blockSize - 1)));
+	audioBuffer.insert(this->audioBuffer.end(), data, data + len);
+	SDL_UnlockAudio();
+	return len;
+#else
+	if (!this->deviceId) {
+		return 0;
+	}
 	U32 queued = this->getGuestQueuedAudioSizeWant();
 	if (queued >= DSP_BUFFER_SIZE) {
 		return -K_EWOULDBLOCK;
@@ -427,8 +615,8 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 #ifdef __EMSCRIPTEN__
 	addRealQueuedWant(len);
 	topUpSilence();
-#endif
 	return len;
+#endif
 }
 
 static U32 nextId = 0;
@@ -463,6 +651,7 @@ void KDspAudio::shutdown() {
 	if (!KSystem::soundEnabled) {
 		return;
 	}	
+#ifdef __EMSCRIPTEN__
 	BOXEDWINE_CRITICAL_SECTION_WITH_MUTEX(pendingClosesMutex);
 	if (drainTimer) {
 		SDL_RemoveTimer(drainTimer);
@@ -475,4 +664,8 @@ void KDspAudio::shutdown() {
 		}
 	}
 	pendingCloses.clear();
+#else
+	SDL_PauseAudio(1);
+	SDL_CloseAudio();
+#endif
 }

--- a/platform/sdl/kdspaudio.cpp
+++ b/platform/sdl/kdspaudio.cpp
@@ -24,19 +24,6 @@
 
 #define DSP_BUFFER_SIZE (1024*32)
 
-#ifndef __EMSCRIPTEN__
-static bool sdlAudioOpen;
-static U8 sdlSilence;
-
-static void closeSdlAudio() {
-	if (sdlAudioOpen) {
-		sdlAudioOpen = false;
-		SDL_PauseAudio(1);
-		SDL_CloseAudio();
-	}
-}
-#endif
-
 class KDspAudioSdl : public KDspAudio, public std::enable_shared_from_this<KDspAudioSdl> {
 public:
 	KDspAudioSdl() {
@@ -61,9 +48,11 @@ public:
 		if (this->cvtBuf) {
 			SDL_free(this->cvtBuf);
 		}
+#ifdef __EMSCRIPTEN__
 		if (this->stream) {
 			SDL_FreeAudioStream(this->stream);
 		}
+#endif
 		if (this->deviceId) {
 			SDL_CloseAudioDevice(this->deviceId);
 			this->deviceId = 0;
@@ -86,11 +75,6 @@ public:
 	}
 	U32 getBufferCapacity() override { return DSP_BUFFER_SIZE;}
 
-#ifndef __EMSCRIPTEN__
-	void onClose();
-	void closeAudioFromAudioThread();
-#endif
-
 	U32 bytesPerSampleWant() {
 		return SDL_AUDIO_BITSIZE(this->want.format) / 8;
 	}
@@ -99,6 +83,7 @@ public:
 		return SDL_AUDIO_BITSIZE(this->got.format) / 8;
 	}
 
+#ifdef __EMSCRIPTEN__
 	U32 bytesPerSecondWant() {
 		return this->want.freq * this->want.channels * bytesPerSampleWant();
 	}
@@ -122,12 +107,9 @@ public:
 	}
 
 	U32 getGuestQueuedAudioSizeWant() {
-#ifdef __EMSCRIPTEN__
 		return this->getEstimatedRealQueuedWant();
-#else
-		return this->getQueuedAudioSizeWant();
-#endif
 	}
+#endif
 
 	U32 getSdlFormat(U32 format) {
 		switch (format) {
@@ -158,22 +140,21 @@ public:
 	SDL_AudioSpec want = { 0 };
 	SDL_AudioSpec got = { 0 };
 	SDL_AudioCVT cvt = { 0 };
+#ifdef __EMSCRIPTEN__
 	SDL_AudioStream* stream = nullptr;
+#endif
 	U32 openedFormat = 0;
 	int cvtBufLen = 0;
-#ifndef __EMSCRIPTEN__
-	int cvtBufPos = 0;
-#endif
 	unsigned char* cvtBuf = nullptr;
+#ifdef __EMSCRIPTEN__
 	std::vector<U8> streamBuffer;
+#endif
 	bool sameFormat = false;
 	U32 dspFragSize = 4096;
 	bool open = false;
-	std::deque<U8> audioBuffer;
+	std::deque<U8> audioBuffer; // only used when KSystem::soundEnabled is false
 	SDL_AudioDeviceID deviceId = 0;
-#ifndef __EMSCRIPTEN__
-	bool closeWhenDone = false;
-#endif
+#ifdef __EMSCRIPTEN__
 	U32 realQueuedWant = 0;
 	U32 lastRealQueuedTime = 0;
 	std::vector<U8> silenceBuffer;
@@ -199,7 +180,6 @@ public:
 	}
 
 	U32 topUpSilence() {
-#ifdef __EMSCRIPTEN__
 		if (!this->deviceId) {
 			return 0;
 		}
@@ -223,85 +203,10 @@ public:
 		SDL_memset(this->silenceBuffer.data(), this->got.silence, bytes);
 		SDL_QueueAudio(this->deviceId, this->silenceBuffer.data(), bytes);
 		return bytes;
-#else
-		return 0;
-#endif
 	}
+#endif
 };
 
-#ifndef __EMSCRIPTEN__
-// Not really a voice; currently voices are not mixed.
-static std::list<std::shared_ptr<KDspAudioSdl>> voices;
-
-static void audioCallback(void* /*userdata*/, U8* stream, S32 len) {
-	if (!voices.size()) {
-		memset(stream, sdlSilence, len);
-		return;
-	}
-	std::shared_ptr<KDspAudioSdl> data = voices.front();
-	if (data->closeWhenDone && data->audioBuffer.size() == 0 && (data->cvtBufPos == 0 || data->cvtBufPos >= data->cvt.len_cvt)) {
-		data->closeAudioFromAudioThread();
-		memset(stream, sdlSilence, len);
-		return;
-	}
-
-	S32 available = (S32)data->audioBuffer.size();
-
-	if (!data->sameFormat) {
-		if (data->cvtBufPos < data->cvt.len_cvt) {
-			S32 todo = data->cvt.len_cvt - data->cvtBufPos;
-			if (todo > len) {
-				todo = len;
-			}
-			memcpy(stream, data->cvt.buf + data->cvtBufPos, todo);
-			data->cvtBufPos += todo;
-			stream += todo;
-			len -= todo;
-		}
-		if (len) {
-			data->cvt.len = available;
-			if (data->cvtBufLen && data->cvtBufLen < data->cvt.len * data->cvt.len_mult) {
-				data->cvtBufLen = 0;
-				SDL_free(data->cvtBuf);
-				data->cvtBuf = nullptr;
-			}
-			if (!data->cvtBufLen) {
-				data->cvtBufLen = data->cvt.len * data->cvt.len_mult;
-				data->cvtBuf = (Uint8*)SDL_malloc(data->cvt.len * data->cvt.len_mult);
-			}
-			data->cvt.buf = data->cvtBuf;
-
-			std::copy(data->audioBuffer.begin(), data->audioBuffer.begin() + available, data->cvt.buf);
-			data->audioBuffer.erase(data->audioBuffer.begin(), data->audioBuffer.begin() + available);
-
-			SDL_ConvertAudio(&data->cvt);
-			S32 todo = data->cvt.len_cvt;
-			if (todo > len) {
-				todo = len;
-			}
-			memcpy(stream, data->cvt.buf, todo);
-			stream += todo;
-			len -= todo;
-			data->cvtBufPos = todo;
-		}
-	} else {
-		if (available > len) {
-			available = len;
-		}
-		if (available) {
-			std::copy(data->audioBuffer.begin(), data->audioBuffer.begin() + available, stream);
-			data->audioBuffer.erase(data->audioBuffer.begin(), data->audioBuffer.begin() + available);
-			len -= available;
-			stream += available;
-		}
-	}
-	if (len) {
-		memset(stream, data->got.silence, len);
-	}
-}
-#endif
-
-#ifdef __EMSCRIPTEN__
 // Voices whose closeAudio was called while audio was still queued to SDL.
 // A timer polls these and finalizes the device close when the queue drains.
 static std::list<std::shared_ptr<KDspAudioSdl>> pendingCloses;
@@ -339,7 +244,6 @@ static void ensureDrainTimer() {
 		drainTimer = SDL_AddTimer(50, drainTimerCb, nullptr);
 	}
 }
-#endif
 
 void KDspAudioSdl::soundEnabled() {
 	if (this->open) {
@@ -348,26 +252,18 @@ void KDspAudioSdl::soundEnabled() {
 }
 
 void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
-#ifdef __EMSCRIPTEN__
 	this->want.callback = nullptr; // SDL_QueueAudio mode
 	this->want.userdata = nullptr;
-#else
-	this->want.callback = audioCallback;
-#endif
 	this->want.format = getSdlFormat(format);
 	this->want.freq = freq;
 	this->want.channels = channels;
 	this->openedFormat = format;
 
 	if (!KSystem::soundEnabled) {
-#ifndef __EMSCRIPTEN__
-		sdlAudioOpen = true;
-#endif
 		this->open = true;
 		return;
 	}
 
-#ifdef __EMSCRIPTEN__
 	{
 		BOXEDWINE_CRITICAL_SECTION_WITH_MUTEX(pendingClosesMutex);
 		// Drop any pending-close entry; we're reusing this voice.
@@ -384,15 +280,13 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
 			SDL_CloseAudioDevice(this->deviceId);
 			this->deviceId = 0;
 		}
+#ifdef __EMSCRIPTEN__
 		if (this->stream) {
 			SDL_FreeAudioStream(this->stream);
 			this->stream = nullptr;
 		}
-	}
-#else
-	// If the previous audio is still playing, it will get cut off. If I find a game that needs this, then perhaps I should think of a mixer.
-	closeSdlAudio();
 #endif
+	}
 
     SDL_AudioSpec requested = this->want;
 #ifdef __MACH__
@@ -400,20 +294,12 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
         requested.freq = 44100;
     }
 #endif
-#ifdef __EMSCRIPTEN__
 	SDL_AudioDeviceID newId = SDL_OpenAudioDevice(nullptr, 0, &requested, &this->got, SDL_AUDIO_ALLOW_ANY_CHANGE);
 	if (newId == 0) {
 		klog_fmt("Failed to open audio: %s", SDL_GetError());
 		return;
 	}
 	this->deviceId = newId;
-#else
-	if (SDL_OpenAudio(&requested, &this->got) < 0) {
-		klog_fmt("Failed to open audio: %s", SDL_GetError());
-	}
-	sdlSilence = this->got.silence;
-	sdlAudioOpen = true;
-#endif
 
 	if (this->want.freq != this->got.freq || this->want.channels != this->got.channels || this->want.format != this->got.format) {
 		this->sameFormat = false;
@@ -430,49 +316,15 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
 	}
 
 	this->open = true;	
-#ifdef __EMSCRIPTEN__
 	SDL_PauseAudioDevice(this->deviceId, 0);
-#else
-	voices.push_back(shared_from_this());
-	SDL_PauseAudio(0);
-	if (this->got.size) {
-		//this->dspFragSize = this->got.size;
-	}
-#endif
 	klog_fmt("openAudio: freq=%d(got %d) format=%x(got %x) channels=%d(got %d)", this->want.freq, this->got.freq, this->want.format, this->got.format, this->want.channels, this->got.channels);
 }
-
-#ifndef __EMSCRIPTEN__
-void KDspAudioSdl::closeAudioFromAudioThread() {
-	if (this->open) {
-		this->onClose();
-	}
-}
-#endif
 
 void KDspAudioSdl::closeAudio() {
 	if (!KSystem::soundEnabled) {
 		this->open = false;
 		return;
 	}
-#ifndef __EMSCRIPTEN__
-	if (this->open) {
-		bool needClose = true;
-		{
-			SDL_LockAudio();
-			if (audioBuffer.size() || (this->cvtBufPos != 0 && this->cvtBufPos < this->cvt.len_cvt)) {
-				closeWhenDone = true;
-				needClose = false;
-			}
-			SDL_UnlockAudio();
-		}
-		if (needClose) {
-			closeSdlAudio();
-			this->onClose();
-		}
-	}
-	return;
-#else
 	if (!this->open) {
 		return;
 	}
@@ -490,28 +342,7 @@ void KDspAudioSdl::closeAudio() {
 		SDL_CloseAudioDevice(this->deviceId);
 		this->deviceId = 0;
 	}
-#endif
 }
-
-#ifndef __EMSCRIPTEN__
-void KDspAudioSdl::onClose() {
-	if (!KSystem::soundEnabled) {
-		this->open = false;
-		return;
-	}
-	auto it = voices.begin();
-	while (it != voices.end()) {
-		std::shared_ptr<KDspAudioSdl> p = *it;
-		if (p == shared_from_this()) {
-			it = voices.erase(it);
-			break;
-		} else {
-			it++;
-		}
-	}
-	this->open = false;
-}
-#endif
 
 void KDspAudioSdl::setFragmentSize(U32 size) {
 #ifdef __EMSCRIPTEN__
@@ -526,13 +357,12 @@ void KDspAudioSdl::setFragmentSize(U32 size) {
 	this->dspFragSize = size ? size : blockSize;
 }
 
-U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
-	U32 wantBytesPerSecond = want.freq * want.channels * bytesPerSampleWant();
-	U32 delay = wantBytesPerSecond / 8;
-
+U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {	
 	if (!KSystem::soundEnabled) {
 		static U32 timeSinceLastWrite;
 
+		U32 wantBytesPerSecond = want.freq * want.channels * bytesPerSampleWant();
+		U32 delay = wantBytesPerSecond / 8;
 		U32 elapsedTime = KSystem::getMilliesSinceStart() - timeSinceLastWrite;
 		U32 bytesToRemove = wantBytesPerSecond * elapsedTime / 1000;
 
@@ -549,25 +379,11 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 		return len;
 	}
 
-	if (!this->open) {
+	if (!this->open || !this->deviceId) {
 		return 0;
 	}
 
-#ifndef __EMSCRIPTEN__
-	SDL_LockAudio();
-	if (this->audioBuffer.size() > delay) {
-		SDL_UnlockAudio();
-		return -K_EWOULDBLOCK;
-	}
-	U32 blockSize = bytesPerSampleWant() * want.channels;
-	len = std::min(len, ((delay - (U32)this->audioBuffer.size()) & ~(blockSize - 1)));
-	audioBuffer.insert(this->audioBuffer.end(), data, data + len);
-	SDL_UnlockAudio();
-	return len;
-#else
-	if (!this->deviceId) {
-		return 0;
-	}
+#ifdef __EMSCRIPTEN__
 	U32 queued = this->getGuestQueuedAudioSizeWant();
 	if (queued >= DSP_BUFFER_SIZE) {
 		return -K_EWOULDBLOCK;
@@ -579,6 +395,7 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 	}
 #endif
 
+#ifdef __EMSCRIPTEN__
 	if (!this->sameFormat && this->stream) {
 		if (SDL_AudioStreamPut(this->stream, data, (int)len) < 0) {
 			return 0;
@@ -594,6 +411,9 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 			}
 		}
 	} else if (!this->sameFormat) {
+#else
+	if (!this->sameFormat) {
+#endif
 		int needed = (int)len * this->cvt.len_mult;
 		if (this->cvtBufLen && this->cvtBufLen < needed) {
 			SDL_free(this->cvtBuf);
@@ -615,8 +435,8 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 #ifdef __EMSCRIPTEN__
 	addRealQueuedWant(len);
 	topUpSilence();
-	return len;
 #endif
+	return len;
 }
 
 static U32 nextId = 0;
@@ -651,7 +471,6 @@ void KDspAudio::shutdown() {
 	if (!KSystem::soundEnabled) {
 		return;
 	}	
-#ifdef __EMSCRIPTEN__
 	BOXEDWINE_CRITICAL_SECTION_WITH_MUTEX(pendingClosesMutex);
 	if (drainTimer) {
 		SDL_RemoveTimer(drainTimer);
@@ -664,8 +483,4 @@ void KDspAudio::shutdown() {
 		}
 	}
 	pendingCloses.clear();
-#else
-	SDL_PauseAudio(1);
-	SDL_CloseAudio();
-#endif
 }

--- a/platform/sdl/kdspaudio.cpp
+++ b/platform/sdl/kdspaudio.cpp
@@ -64,7 +64,13 @@ public:
 	U32 writeAudio(U8* data, U32 len) override;
 	U32 getFragmentSize() override {return this->dspFragSize;}
 	void setFragmentSize(U32 size) override;
-	U32 getBufferSize() override {return this->getGuestQueuedAudioSizeWant();}
+	U32 getBufferSize() override {
+#ifdef __EMSCRIPTEN__
+		return this->getGuestQueuedAudioSizeWant();
+#else
+		return 0;
+#endif
+	}
 	U32 getBufferCapacity() override { return DSP_BUFFER_SIZE;}
 
 	U32 bytesPerSampleWant() {
@@ -293,10 +299,14 @@ void KDspAudioSdl::openAudio(U32 format, U32 freq, U32 channels) {
 
 	if (this->want.freq != this->got.freq || this->want.channels != this->got.channels || this->want.format != this->got.format) {
 		this->sameFormat = false;
+#ifdef __EMSCRIPTEN__
 		this->stream = SDL_NewAudioStream(this->want.format, this->want.channels, this->want.freq, this->got.format, this->got.channels, this->got.freq);
 		if (!this->stream) {
 			SDL_BuildAudioCVT(&this->cvt, this->want.format, this->want.channels, this->want.freq, this->got.format, this->got.channels, this->got.freq);
 		}
+#else
+		SDL_BuildAudioCVT(&this->cvt, this->want.format, this->want.channels, this->want.freq, this->got.format, this->got.channels, this->got.freq);
+#endif
 	} else {
 		this->sameFormat = true;
 	}
@@ -369,6 +379,7 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 		return 0;
 	}
 
+#ifdef __EMSCRIPTEN__
 	U32 queued = this->getGuestQueuedAudioSizeWant();
 	if (queued >= DSP_BUFFER_SIZE) {
 		return -K_EWOULDBLOCK;
@@ -378,6 +389,7 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 	if (!len) {
 		return -K_EWOULDBLOCK;
 	}
+#endif
 
 	if (!this->sameFormat && this->stream) {
 		if (SDL_AudioStreamPut(this->stream, data, (int)len) < 0) {
@@ -412,8 +424,10 @@ U32 KDspAudioSdl::writeAudio(U8* data, U32 len) {
 	} else {
 		SDL_QueueAudio(this->deviceId, data, len);
 	}
+#ifdef __EMSCRIPTEN__
 	addRealQueuedWant(len);
 	topUpSilence();
+#endif
 	return len;
 }
 

--- a/source/kernel/devs/devdsp.cpp
+++ b/source/kernel/devs/devdsp.cpp
@@ -21,7 +21,9 @@
 #include "kscheduler.h"
 #include "../../io/fsvirtualopennode.h"
 #include "oss.h"
+#ifdef __EMSCRIPTEN__
 #include <algorithm>
+#endif
 #include <math.h>
 #include <string.h>
 #include "kdspaudio.h"
@@ -29,11 +31,8 @@
 #ifdef __EMSCRIPTEN__
 static U32 dspMaxOutputFreq = 11025;
 static const U32 DSP_DEFAULT_FRAGMENT_SIZE = 1024;
-#else
-static U32 dspMaxOutputFreq = 48000;
-static const U32 DSP_DEFAULT_FRAGMENT_SIZE = 4096;
-#endif
 static const U32 DSP_DEFAULT_FRAGMENT_COUNT = 8;
+#endif
 
 class DevDsp : public FsVirtualOpenNode {
 public:
@@ -54,12 +53,15 @@ public:
     U32 readNative(U8* buffer, U32 len) override;
     U32 writeNative(U8* buffer, U32 len) override;
     void waitForEvents(BOXEDWINE_CONDITION& parentCondition, U32 events) override;
+#ifdef __EMSCRIPTEN__
     bool isWriteReady() override;
+#endif
 
     std::shared_ptr<KDspAudio> audio;
     U32 freq;
     U32 channels;
     U32 format;
+#ifdef __EMSCRIPTEN__
     U32 fragmentCount = DSP_DEFAULT_FRAGMENT_COUNT;
     U32 bytesWritten = 0;
     U32 lastOutputBlocks = 0;
@@ -68,6 +70,7 @@ private:
     U32 getEffectiveBufferCapacity();
     U32 getUsedBufferSize();
     U32 getAvailableBufferSize();
+#endif
 };
 
 
@@ -75,17 +78,15 @@ void dspShutdown() {
     KDspAudio::shutdown();
 }
 
-void dspSetMaxOutputFreq(U32 freq) {
 #ifdef __EMSCRIPTEN__
+void dspSetMaxOutputFreq(U32 freq) {
     if (freq == 11025 || freq == 22050) {
         dspMaxOutputFreq = freq;
     } else {
         kwarn_fmt("Unsupported Emscripten audio frequency %d, using %d", freq, dspMaxOutputFreq);
     }
-#else
-    dspMaxOutputFreq = freq;
-#endif
 }
+#endif
 
 bool DevDsp::setLength(S64 len) {
     return false;
@@ -110,14 +111,11 @@ U32 DevDsp::writeNative(U8* buffer, U32 len) {
 #endif
 }
 
+#ifdef __EMSCRIPTEN__
 U32 DevDsp::getEffectiveBufferCapacity() {
     U32 capacity = this->audio->getBufferCapacity();
-#ifdef __EMSCRIPTEN__
     U32 fragmentCapacity = this->audio->getFragmentSize() * this->fragmentCount;
     return std::min(capacity, fragmentCapacity ? fragmentCapacity : capacity);
-#else
-    return capacity;
-#endif
 }
 
 U32 DevDsp::getUsedBufferSize() {
@@ -129,12 +127,9 @@ U32 DevDsp::getAvailableBufferSize() {
 }
 
 bool DevDsp::isWriteReady() {
-#ifdef __EMSCRIPTEN__
     return this->getAvailableBufferSize() >= this->audio->getFragmentSize();
-#else
-    return true;
-#endif
 }
+#endif
 
 U32 DevDsp::ioctl(KThread* thread, U32 request) {
     U32 len = (request >> 16) & 0x3FFF;
@@ -146,11 +141,11 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 
     switch (request & 0xFFFF) {
     case 0x5000: // SNDCTL_DSP_RESET
-#ifdef __EMSCRIPTEN__
         this->audio->closeAudio();
         this->freq = 8000;
         this->channels = 1;
         this->format = AFMT_U8;
+#ifdef __EMSCRIPTEN__
         this->audio->setFragmentSize(DSP_DEFAULT_FRAGMENT_SIZE);
         this->fragmentCount = DSP_DEFAULT_FRAGMENT_COUNT;
         this->bytesWritten = 0;

--- a/source/kernel/devs/devdsp.cpp
+++ b/source/kernel/devs/devdsp.cpp
@@ -42,7 +42,9 @@ public:
         this->freq = 11025;
         this->channels = 1;
         this->format = AFMT_U8;
+#ifdef __EMSCRIPTEN__
         this->audio->setFragmentSize(DSP_DEFAULT_FRAGMENT_SIZE);
+#endif
     } 
     virtual ~DevDsp() {this->audio->closeAudio();}
 
@@ -97,17 +99,25 @@ U32 DevDsp::writeNative(U8* buffer, U32 len) {
     if (!this->audio->isOpen()) {
         this->audio->openAudio(this->format, this->freq, this->channels);
     }
+#ifdef __EMSCRIPTEN__
     U32 result = this->audio->writeAudio(buffer, len);
     if ((S32)result > 0) {
         this->bytesWritten += result;
     }
     return result;
+#else
+    return this->audio->writeAudio(buffer, len);
+#endif
 }
 
 U32 DevDsp::getEffectiveBufferCapacity() {
     U32 capacity = this->audio->getBufferCapacity();
+#ifdef __EMSCRIPTEN__
     U32 fragmentCapacity = this->audio->getFragmentSize() * this->fragmentCount;
     return std::min(capacity, fragmentCapacity ? fragmentCapacity : capacity);
+#else
+    return capacity;
+#endif
 }
 
 U32 DevDsp::getUsedBufferSize() {
@@ -119,7 +129,11 @@ U32 DevDsp::getAvailableBufferSize() {
 }
 
 bool DevDsp::isWriteReady() {
+#ifdef __EMSCRIPTEN__
     return this->getAvailableBufferSize() >= this->audio->getFragmentSize();
+#else
+    return true;
+#endif
 }
 
 U32 DevDsp::ioctl(KThread* thread, U32 request) {
@@ -136,18 +150,25 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         this->freq = 8000;
         this->channels = 1;
         this->format = AFMT_U8;
+#ifdef __EMSCRIPTEN__
         this->audio->setFragmentSize(DSP_DEFAULT_FRAGMENT_SIZE);
         this->fragmentCount = DSP_DEFAULT_FRAGMENT_COUNT;
         this->bytesWritten = 0;
         this->lastOutputBlocks = 0;
+#endif
         return 0;
     case 0x5002: { // SNDCTL_DSP_SPEED 
         if (len!=4) {
             kpanic("SNDCTL_DSP_SPEED was expecting a len of 4");
         }
-		U32 oldFreq = this->freq;
-		this->freq = std::min(memory->readd(IOCTL_ARG1), dspMaxOutputFreq);
+#ifdef __EMSCRIPTEN__
+        U32 oldFreq = this->freq;
+        this->freq = std::min(memory->readd(IOCTL_ARG1), dspMaxOutputFreq);
         if (oldFreq != this->freq) {
+#else
+		this->freq = memory->readd(IOCTL_ARG1);
+        if (freq != this->freq) {
+#endif
             this->audio->closeAudio();
         }
 		if (write)
@@ -209,7 +230,11 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 			this->format = AFMT_U8;
             break;
         case AFMT_FLOAT:
+#ifdef __EMSCRIPTEN__
             this->format = AFMT_S16_LE;
+#else
+            this->format = AFMT_FLOAT;
+#endif
             break;
         }
         if (write)
@@ -235,7 +260,9 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
             memory->writed(IOCTL_ARG1, this->channels);
         return 0;
         }
-    case 0x500A: { // SNDCTL_DSP_SETFRAGMENT
+    case 0x500A: // SNDCTL_DSP_SETFRAGMENT
+#ifdef __EMSCRIPTEN__
+    {
         U32 value = memory->readd(IOCTL_ARG1);
         U32 shift = value & 0xFFFF;
         U32 count = value >> 16;
@@ -246,8 +273,17 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         this->fragmentCount = std::clamp(count, (U32)2, (U32)64);
         return 0;
     }
+#else
+		// this->data->dspFragSize = 1 << (readd(IOCTL_ARG1) & 0xFFFF);
+        klog("DevDsp::ioctl was not expecting SNDCTL_DSP_SETFRAGMENT");
+        return 0;
+#endif
     case 0x500B: // SNDCTL_DSP_GETFMTS
+#ifdef __EMSCRIPTEN__
         memory->writed(IOCTL_ARG1, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_LE | AFMT_U16_BE);
+#else
+        memory->writed(IOCTL_ARG1, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_LE | AFMT_U16_BE | AFMT_FLOAT);
+#endif
         return 0;
 
 		//typedef struct audio_buf_info {
@@ -261,6 +297,7 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 
     case 0x500C: // SNDCTL_DSP_GETOSPACE
     {
+#ifdef __EMSCRIPTEN__
         U32 capacity = this->getEffectiveBufferCapacity();
         U32 used = this->getUsedBufferSize();
         U32 available = capacity - used;
@@ -268,6 +305,13 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         memory->writed(IOCTL_ARG1 + 4, capacity / this->audio->getFragmentSize());
         memory->writed(IOCTL_ARG1 + 8, this->audio->getFragmentSize());
         memory->writed(IOCTL_ARG1 + 12, available);
+#else
+        // I'm not sure why bytes works better as getBufferCapacity instead of getBufferCapacity - getBufferSize, but mac stutters a lot otherwise
+        memory->writed(IOCTL_ARG1, this->audio->getBufferCapacity() / this->audio->getFragmentSize()); // fragments
+        memory->writed(IOCTL_ARG1 + 4, this->audio->getBufferCapacity() / this->audio->getFragmentSize());
+        memory->writed(IOCTL_ARG1 + 8, this->audio->getFragmentSize());
+        memory->writed(IOCTL_ARG1 + 12, this->audio->getBufferCapacity());
+#endif
         return 0;
     }
     case 0x500F: // SNDCTL_DSP_GETCAPS
@@ -291,7 +335,9 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         */
         klog("DevDsp::ioctl was not expecting SNDCTL_DSP_SETTRIGGER");
         return 0;
-    case 0x5012: { // SNDCTL_DSP_GETOPTR
+    case 0x5012: // SNDCTL_DSP_GETOPTR
+#ifdef __EMSCRIPTEN__
+    {
         U32 fragmentSize = this->audio->getFragmentSize();
         U32 currentBlocks = fragmentSize ? this->bytesWritten / fragmentSize : 0;
         U32 blocks = currentBlocks - this->lastOutputBlocks;
@@ -302,11 +348,40 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
         memory->writed(IOCTL_ARG1 + 8, capacity ? this->bytesWritten % capacity : 0); // Current DMA pointer value
         return 0;
     }
+#else
+        /*
+        writed(IOCTL_ARG1, 0); // Total # of bytes processed
+        writed(IOCTL_ARG1 + 4, 0); // # of fragment transitions since last time
+        if (data->pauseEnabled()) {
+			writed(IOCTL_ARG1 + 8, this->data->pauseAtLen); // Current DMA pointer value
+			if (this->data->pauseAtLen == 0) {
+                if (sdlSoundEnabled) {
+                    SDL_PauseAudio(0);
+                }
+            }
+        } else {
+			writed(IOCTL_ARG1 + 8, (U32)audioBuffer.size()); // Current DMA pointer value
+        }
+        */
+        klog("DevDsp::ioctl was not expecting SNDCTL_DSP_GETOPTR");
+        return 0;
+#endif
     case 0x5016: // SNDCTL_DSP_SETDUPLEX
         return -K_EINVAL;
     case 0x5017: // SNDCTL_DSP_GETODELAY
+#ifdef __EMSCRIPTEN__
         memory->writed(IOCTL_ARG1, this->getUsedBufferSize());
         return 0;
+#else
+        /*
+        if (write) {
+			writed(IOCTL_ARG1, (U32)audioBuffer.size());
+            return 0;
+        }
+        */
+        klog("DevDsp::ioctl was not expecting SNDCTL_DSP_GETODELAY");
+        return 0;
+#endif
     case 0x580C: // SNDCTL_ENGINEINFO
         if (write) {
             U32 p = IOCTL_ARG1;
@@ -316,7 +391,11 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
             memory->writed(p, -1); p+=4; // int pid;
             memory->writed(p, PCM_CAP_OUTPUT); p+=4; // int caps;			/* PCM_CAP_INPUT, PCM_CAP_OUTPUT */
             memory->writed(p, 0); p+=4; // int iformats
+#ifdef __EMSCRIPTEN__
             memory->writed(p, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_BE); p+=4; // int oformats;
+#else
+            memory->writed(p, AFMT_U8 | AFMT_S16_LE | AFMT_S16_BE | AFMT_S8 | AFMT_U16_BE | AFMT_FLOAT); p+=4; // int oformats;
+#endif
             memory->writed(p, 0); p+=4; // int magic;			/* Reserved for internal use */
             memory->strcpy(p, ""); p+=64; // oss_cmd_t cmd;		/* Command using the device (if known) */
             memory->writed(p, 0); p+=4; // int card_number;
@@ -326,7 +405,11 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
             memory->writed(p, 1); p+=4; // int enabled;			/* 1=enabled, 0=device not ready at this moment */
             memory->writed(p, 0); p+=4; // int flags;			/* For internal use only - no practical meaning */
             memory->writed(p, 11025); p += 4; // int min_rate
+#ifdef __EMSCRIPTEN__
             memory->writed(p, dspMaxOutputFreq); p+=4; // max_rate;	/* Sample rate limits */
+#else
+            memory->writed(p, 48000); p+=4; // max_rate;	/* Sample rate limits */
+#endif
             memory->writed(p, 1); p+=4; // int min_channels
             memory->writed(p, 2); p+=4; // max_channels;	/* Number of channels supported */
             memory->writed(p, 0); p+=4; // int binding;			/* DSP_BIND_FRONT, etc. 0 means undefined */
@@ -350,9 +433,14 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 
 void DevDsp::waitForEvents(BOXEDWINE_CONDITION& parentCondition, U32 events) {
     if (events & K_POLLOUT) {
+#ifdef __EMSCRIPTEN__
         if (this->isWriteReady()) {
             BOXEDWINE_CONDITION_SIGNAL_ALL(parentCondition);
         }
+#else
+        // BOXEDWINE_CONDITION_ADD_CHILD_CONDITION(parentCondition, this->data->bufferCond, nullptr);
+        klog("DevDsp::waitForEvents POLLOUT not implemented");
+#endif
     }
 }
 

--- a/source/kernel/devs/devdsp.cpp
+++ b/source/kernel/devs/devdsp.cpp
@@ -146,11 +146,11 @@ U32 DevDsp::ioctl(KThread* thread, U32 request) {
 
     switch (request & 0xFFFF) {
     case 0x5000: // SNDCTL_DSP_RESET
+#ifdef __EMSCRIPTEN__
         this->audio->closeAudio();
         this->freq = 8000;
         this->channels = 1;
         this->format = AFMT_U8;
-#ifdef __EMSCRIPTEN__
         this->audio->setFragmentSize(DSP_DEFAULT_FRAGMENT_SIZE);
         this->fragmentCount = DSP_DEFAULT_FRAGMENT_COUNT;
         this->bytesWritten = 0;

--- a/source/kernel/kscheduler.cpp
+++ b/source/kernel/kscheduler.cpp
@@ -128,17 +128,16 @@ static const S32 DEFAULT_CONTEXT_TIME = 10000;
 static const S32 MIN_CONTEXT_TIME = 2000;
 static const S32 MAX_CONTEXT_TIME = 10000;
 static const S32 CONTEXT_TIME_STEP = 1000;
-#else
-static const S32 DEFAULT_CONTEXT_TIME = 100000;
-static const S32 MIN_CONTEXT_TIME = 100000;
-static const S32 MAX_CONTEXT_TIME = 0x7FFFFFFF;
-static const S32 CONTEXT_TIME_STEP = 20000;
-#endif
 S32 contextTime = DEFAULT_CONTEXT_TIME;
 S32 contextTimeRemaining = DEFAULT_CONTEXT_TIME;
+#else
+S32 contextTime = 100000;
+S32 contextTimeRemaining = 100000;
+#endif
 int count;
 extern struct Block emptyBlock;
 
+#ifdef __EMSCRIPTEN__
 static S32 decreaseContextTime(S32 value) {
     if (value <= MIN_CONTEXT_TIME + CONTEXT_TIME_STEP) {
         return MIN_CONTEXT_TIME;
@@ -152,6 +151,7 @@ static S32 increaseContextTime(S32 value) {
     }
     return value + CONTEXT_TIME_STEP;
 }
+#endif
 
 void runThreadSlice(KThread* thread) {
     CPU* cpu;
@@ -241,9 +241,18 @@ bool runSlice() {
     }
     if (!scheduledThreads.isEmpty()) {
         if (elapsedTime>11000) {
+#ifdef __EMSCRIPTEN__
             contextTime = decreaseContextTime(contextTime);
+#else
+            if (contextTime>100000)
+                contextTime-=20000;
+#endif
         } else if (elapsedTime<9500) {
+#ifdef __EMSCRIPTEN__
             contextTime = increaseContextTime(contextTime);
+#else
+            contextTime+=20000;
+#endif
         }
     }
     //klog("ran slice in %dus %d", (U32)elapsedTime, contextTime);    

--- a/source/sdl/startupArgs.cpp
+++ b/source/sdl/startupArgs.cpp
@@ -561,9 +561,11 @@ bool StartUpArgs::apply() {
         }
     }
     KSystem::videoOption = this->videoOption;
+#ifdef __EMSCRIPTEN__
     if (this->audioFreq) {
         dspSetMaxOutputFreq(this->audioFreq);
     }
+#endif
     KSystem::soundEnabled = this->soundEnabled;
 #ifdef __EMSCRIPTEN__
     if (KSystem::soundEnabled) {
@@ -695,6 +697,7 @@ bool StartUpArgs::parseStartupArgs(int argc, const char **argv) {
             this->workingDirSet = true;
         } else if (!strcmp(argv[i], "-nosound")) {
 			this->soundEnabled = false;
+#ifdef __EMSCRIPTEN__
         } else if (!strcmp(argv[i], "-audioFreq") && i+1<argc) {
             U32 audioFreq = atoi(argv[i+1]);
             if (audioFreq == 11025 || audioFreq == 22050) {
@@ -703,6 +706,7 @@ bool StartUpArgs::parseStartupArgs(int argc, const char **argv) {
                 klog("-audioFreq must be 11025 or 22050");
             }
             i++;
+#endif
         } else if (!strcmp(argv[i], "-novideo")) {
 #ifdef BOXEDWINE_MSVC
             this->videoOption = VIDEO_HIDE_WINDOW;

--- a/source/sdl/startupArgs.h
+++ b/source/sdl/startupArgs.h
@@ -94,7 +94,9 @@ public:
     int effectiveGroupId = GID;
 
     bool soundEnabled = true;
+#ifdef __EMSCRIPTEN__
     U32 audioFreq = 0;
+#endif
     VideoOption videoOption = VIDEO_NORMAL;
     U32 vsync = VSYNC_DEFAULT;
     bool dpiAware = false;


### PR DESCRIPTION
This keeps the changes to support smooth emscripten sound, while reverting audio for non-emscripten builds back to pre merge state.
While working on this it became clear that on ubuntu linux i am seeing a large lag before sound is played. This matches pre-merge behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform-specific audio output frequency configuration now available.

* **Improvements**
  * Audio handling optimized per deployment platform with refined format support.
  * Scheduler timing tuned for enhanced performance on select platforms.

* **Changes**
  * Startup parameter handling updated for audio configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danoon2/Boxedwine/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->